### PR TITLE
Adding new Ikea Bulb E14

### DIFF
--- a/DeviceConf.txt
+++ b/DeviceConf.txt
@@ -22,6 +22,7 @@
 'plug.Osram':{'Ep':{'03':{'0006'}},'Type':'Plug','ProfileID':'c05e','ZDeviceID':'0010'},
 'TRADFRI bulb E27 W opal 1000lm':{'Ep':{'01':{'0000':'','0003':'','0004':'','0005':'','0006':'','0008':'','0b05':'','1000':'','Type':'LvlControl'}},'Type':'','ProfileID':'c05e','ZDeviceID':'0100','NickName':'LED1623G12'},
 'TRADFRI bulb GU10 W 400lm':{'Ep':{'01':{'0000':'','0003':'','0004':'','0005':'','0006':'','0008':'','0b05':'','1000':'','Type':'LvlControl'}},'Type':'','ProfileID':'c05e','ZDeviceID':'0100','NickName':'LED1536G5'},
+'TRADFRI bulb E14 W op/ch 400lm':{'Ep':{'01':{'0000':'','0003':'','0004':'','0005':'','0006':'','0008':'','0b05':'','1000':'','Type':'LvlControl'}},'Type':'','ProfileID':'c05e','ZDeviceID':'0100','NickName':'LED1649C5'},
 'TRADFRI bulb E27 CWS opal 600lm':{'Ep':{'01':{'0000':'','0003':'','0004':'','0005':'','0006':'','0008':'','0300':'','0b05':'','1000':'','Type':'ColorControl'}},'Type':'','ProfileID':'c05e','ZDeviceID':'0200','NickName':'LED1624G9'},
 'TRADFRI bulb E27 WS opal 950lm':{'Ep':{'01':{'0000':'','0003':'','0004':'','0005':'','0006':'','0008':'','0300':'','0b05':'','1000':'','Type':'ColorControl','ColorMode':'2'}},'Type':'','ProfileID':'c05e','ZDeviceID':'0220','NickName':'LED1545G12'},
 'TRADFRI bulb E27 WS clear 950lm':{'Ep':{'01':{'0000':'','0003':'','0004':'','0005':'','0006':'','0008':'','0300':'','0b05':'','1000':'','Type':'ColorControl','ColorMode':'2'}},'Type':'','ProfileID':'c05e','ZDeviceID':'0220','NickName':'LED1546G12'},


### PR DESCRIPTION
Adding Ikea Bulb E14 socket : 

'TRADFRI bulb E14 W op/ch 400lm':{'Ep':{'01':{'0000':'','0003':'','0004':'','0005':'','0006':'','0008':'','0b05':'','1000':'','Type':'LvlControl'}},'Type':'','ProfileID':'c05e','ZDeviceID':'0100','NickName':'LED1649C5'},

https://www.ikea.com/fr/fr/catalog/products/60365271/