### PR TITLE
Fix Domoticz.Log for Clusterfc00 OFF Button

### DIFF
--- a/Modules/readClusters.py
+++ b/Modules/readClusters.py
@@ -958,7 +958,7 @@ def Clusterfc00( self, Devices, MsgSQN, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgA
         onoffValue = 1
 
     elif MsgAttrID == '0004': # Off  Button
-        Domoticz.Log("ReadCluster - %s - %s/%s - ON Button detected" %(MsgClusterId, MsgSrcAddr, MsgSrcEp))
+        Domoticz.Log("ReadCluster - %s - %s/%s - OFF Button detected" %(MsgClusterId, MsgSrcAddr, MsgSrcEp))
         onoffValue = 0
 
     elif MsgAttrID in  ( '0002', '0003' ): # Dim+ / 0002 is +, 0003 is -


### PR DESCRIPTION
OFF log was sent when OFF Button is pressed

2019-02-16 13:26:30.789  (Zigate) ReadCluster - fc00 - 2075/02 - OFF Button detected
2019-02-16 13:26:30.789  (Zigate) ReadCluster - fc00 - 2075/02 - new OnOff: 0, Lvl: 10 => Value for Domo: 00
