### PR TITLE
Missing wireless switch (the little square one with one round button)

### DIFF
--- a/Conf/DeviceConf.txt
+++ b/Conf/DeviceConf.txt
@@ -6,6 +6,7 @@
     "lumi.sensor_magnet":{"Ep":{"01":{"0006":""}},"Type":"Door"},
     "lumi.sensor_motion":{"Ep":{"01":{"0006":""}},"Type":"Motion"},
     "lumi.sensor_switch.aq2":{"Ep":{"01":{"0006":""}},"Type":"SwitchAQ2"},
+    "lumi.remote.b1acn01":{"Ep":{"01":{"0006"}},'Type':"SwitchAQ2"},
     "lumi.sensor_switch":{"Ep":{"01":{"0006":""}},"Type":"SwitchAQ2"},
     "lumi.sensor_86sw2":{"Ep":{"01":{"0006":""},"02":{"0006":""}},"Type":"DButton"},
     "lumi.remote.b286acn01":{"Ep":{"01":{"0006":""},"02":{"0006":""}},"Type":"DButton_3"},


### PR DESCRIPTION
In regards to : https://www.domoticz.com/forum/viewtopic.php?f=68&t=27454&p=210534#p210534

It looks like this entry has been removed from an earlier version of the plugin

'lumi.remote.b1acn01':{'Ep':{'01':{'0006'}},'Type':'SwitchAQ2'},