### PR TITLE
Mistake in the Configure Reporting computation

### DIFF
--- a/Modules/output.py
+++ b/Modules/output.py
@@ -756,6 +756,7 @@ def processConfigureReporting( self, NWKID=None ):
                         return # Will do at the next round
 
                     if self.pluginconf.allowReBindingClusters:
+                        del self.ListOfDevices[key]['Bind']
                         bindDevice( self, self.ListOfDevices[key]['IEEE'], Ep, cluster )
 
                     self.ListOfDevices[key]['ConfigureReporting']['TimeStamps'][_idx] = int(time())

--- a/Modules/output.py
+++ b/Modules/output.py
@@ -770,7 +770,6 @@ def processConfigureReporting( self, NWKID=None ):
                         maxInter = ATTRIBUTESbyCLUSTERS[cluster]['Attributes'][attr]['MaxInterval']
                         timeOut = ATTRIBUTESbyCLUSTERS[cluster]['Attributes'][attr]['TimeOut']
                         chgFlag = ATTRIBUTESbyCLUSTERS[cluster]['Attributes'][attr]['Change']
-                        attrList = attrdirection + attrType + attr + minInter + maxInter + timeOut + chgFlag
 
                         attrList += attrdirection + attrType + attr + minInter + maxInter + timeOut + chgFlag
                         attrLen += 1


### PR DESCRIPTION
While building the list of Attribute it looks like the first attribute is put twice in the command to be send to Zigate.