### PR TITLE
support for long press release on Aqara switch

### DIFF
--- a/Modules/domoticz.py
+++ b/Modules/domoticz.py
@@ -920,7 +920,7 @@ def MajDomoDevice(self, Devices, NWKID, Ep, clusterID, value, Attribute_='', Col
                     if value == 1: state = "00"
                     elif value == 2: state = "10"
                     elif value == 3: state = "20"
-                    elif value == 4: state = "30"
+                    elif value == 255: state = "30"
                     else:
                         return  # Simply return and don't process any other values than the above
                     UpdateDevice_v2(self, Devices, x, int(value), str(state), BatteryLevel, SignalLevel, ForceUpdate_=True)


### PR DESCRIPTION
Change to support the 'long press release' event of the Aqara remote switch (Small square one with one round button)