### PR TITLE
Extended panid 399

### DIFF
--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -47,6 +47,7 @@ class PluginConf:
         self.enableAPSFailureLoging = 0
         self.allowOTA = 0
         self.waitingOTA = 3600
+        self.extendedPANID = None
 
         # Plugin Transport
         self.zmode = 'ZigBee'  # Default mode. Cmd -> Ack -> Data
@@ -269,6 +270,14 @@ class PluginConf:
                     self.PluginConf.get('zTimeOut').isdigit():
                 self.zTimeOut = int(self.PluginConf.get('zTimeOut'))
                 Domoticz.Status(" -zTimeOut: %s" %self.zTimeOut)
+
+            if self.PluginConf.get('extendedPANID'):
+                if is_hex( self.PluginConf.get('extendedPANID') ):
+                    self.extendedPANID = int(self.PluginConf.get('extendedPANID'), 16)
+                    Domoticz.Status(" -extendedPANID: 0x%x" %self.extendedPANID)
+                else:
+                    Domoticz.Error("PluginConf - wrong parameter extendedPANID must be hex. %s" \
+                            %self.PluginConf.get('extendedPANID'))
 
         Domoticz.Debug("Device Management:")
         Domoticz.Debug(" -allowStoreDiscoveryFrames : %s" %self.allowStoreDiscoveryFrames)

--- a/Modules/output.py
+++ b/Modules/output.py
@@ -41,22 +41,11 @@ def start_Zigate(self):
     Purpose is to run the start sequence for the Zigate
     it is call when Network is not started.
 
-    1- Set the channel 
-    2- Set Timeserver
-    3- Set the Mode : Coordinator
-    4- Set Extended PANID (if existing )
-    5- Start network ( 0x0024)
     """
 
-    #1
     Domoticz.Status("ZigateConf setting Channel(s) to: %s" \
             %self.pluginconf.channel)
     setChannel(self, self.pluginconf.channel)
-
-    #4
-    if self.pluginconf.extendedPANID:
-        Domoticz.Status("ZigateConf - Setting extPANID : 0x%x" %( self.pluginconf.extendedPANID) )
-        setExtendedPANID(self, self.pluginconf.extendedPANID)
 
     #3
     Domoticz.Status("Set Zigate as a Coordinator")
@@ -998,9 +987,8 @@ def setExtendedPANID(self, extPANID):
     '''
 
     datas = "%016x" %extPANID
-    Domoticz.Log("set ExtendedPANID - %016x "\
+    Domoticz.Debug("set ExtendedPANID - %016x "\
             %( extPANID) )
-    Domoticz.Log("setExtendedPANID - datas: %s" %datas)
     sendZigateCmd(self, "0020", datas )
 
 def leaveMgtReJoin( self, saddr, ieee, rejoin=True):

--- a/Modules/output.py
+++ b/Modules/output.py
@@ -41,23 +41,34 @@ def start_Zigate(self):
     Purpose is to run the start sequence for the Zigate
     it is call when Network is not started.
 
-    2- Set the channel 
+    1- Set the channel 
+    2- Set Timeserver
     3- Set the Mode : Coordinator
-    4- Start network ( 0x0024)
+    4- Set Extended PANID (if existing )
+    5- Start network ( 0x0024)
     """
 
-    Domoticz.Status("Set Zigate as a Coordinator")
-    sendZigateCmd(self, "0023","00")
-
+    #1
     Domoticz.Status("ZigateConf setting Channel(s) to: %s" \
             %self.pluginconf.channel)
     setChannel(self, self.pluginconf.channel)
 
+    #4
+    if self.pluginconf.extendedPANID:
+        Domoticz.Status("ZigateConf - Setting extPANID : 0x%x" %( self.pluginconf.extendedPANID) )
+        setExtendedPANID(self, self.pluginconf.extendedPANID)
+
+    #3
+    Domoticz.Status("Set Zigate as a Coordinator")
+    sendZigateCmd(self, "0023","00")
+
+    #2
     EPOCTime = datetime(2000,1,1)
     UTCTime = int((datetime.now() - EPOCTime).total_seconds())
     Domoticz.Status("ZigateConf - Setting UTC Time to : %s" %( UTCTime) )
     sendZigateCmd(self, "0016", str(UTCTime) )
 
+    #5
     Domoticz.Status("Start network")
     sendZigateCmd(self, "0024", "" )   # Start Network
 
@@ -65,73 +76,8 @@ def start_Zigate(self):
     sendZigateCmd( self, "0014", "" ) # Request status
     sendZigateCmd( self, "0009", "" ) # Request status
 
-
-def ZigateConf_light(self ):
-    '''
-    It is called for normal startup
-    '''
-    sendZigateCmd(self, "0010", "") # Get Firmware version
-
-    Domoticz.Debug("ZigateConf -  Request: Get List of Device " + str(self.FirmwareVersion))
-    sendZigateCmd(self, "0015", "")
-
-    # As per https://www.nxp.com/docs/en/user-guide/JN-UG-3077.pdf
-    # Page 263
-    # Set Time since  0 hours, 0 minutes, 0 seconds, on the 1st of January, 2000 UTC
-    EPOCTime = datetime(2000,1,1)
-    UTCTime = int((datetime.now() - EPOCTime).total_seconds())
-
-    Domoticz.Status("ZigateConf - Setting UTC Time to : %s" %( UTCTime) )
-    sendZigateCmd(self, "0016", str(UTCTime) )
-
-    sendZigateCmd(self, "0009", "") # In order to get Zigate IEEE and NetworkID
-
-    #Domoticz.Status("Start network scan")
-    #sendZigateCmd(self, "0025", "" )   # Start Network Scan ( Network Formation )
-
-    Domoticz.Status("Start network")
-    sendZigateCmd(self, "0024", "" )   # Start Network
-
-
-def ZigateConf(self ):
-    '''
-    Called after Erase and Software Reset
-    '''
-    ################### ZiGate - get Firmware version #############
-    # answer is expected on message 8010
-    sendZigateCmd(self, "0010","")
-
-    ################### ZiGate - Set Type COORDINATOR #################
-    sendZigateCmd(self, "0023","00")
-
-    ################### ZiGate - set channel ##################
-    Domoticz.Status("ZigateConf setting Channel(s) to: %s" %self.pluginconf.channel)
-    setChannel(self, self.pluginconf.channel)
-
-    # As per https://www.nxp.com/docs/en/user-guide/JN-UG-3077.pdf
-    # Page 263
-    # Set Time since  0 hours, 0 minutes, 0 seconds, on the 1st of January, 2000 UTC
-    EPOCTime = datetime(2000,1,1)
-    UTCTime = int((datetime.now() - EPOCTime).total_seconds())
-    Domoticz.Status("ZigateConf - Setting UTC Time to : %s" %( UTCTime) )
-    sendZigateCmd(self, "0016", str(UTCTime) )
-
-    ################### ZiGate - start network ##################
-    sendZigateCmd(self, "0024","")
-
-    sendZigateCmd(self, "0009","") # In order to get Zigate IEEE and NetworkID
-
-    ################### ZiGate - Request Device List #############
-    # answer is expected on message 8015. Only available since firmware 03.0b
-    Domoticz.Debug("ZigateConf -  Request: Get List of Device " + str(self.FirmwareVersion) )
-    sendZigateCmd(self, "0015","")
-
-    Domoticz.Debug("Request network Status")
-    sendZigateCmd( self, "0014", "" ) # Request status
-        
 def sendZigateCmd(self, cmd,datas ):
     self.ZigateComm.sendData( cmd, datas )
-
 
 def ReadAttributeReq( self, addr, EpIn, EpOut, Cluster , ListOfAttributes ):
 
@@ -1051,9 +997,10 @@ def setExtendedPANID(self, extPANID):
     ZigBee communicates using the shorter 16-bit PAN ID for all communication except one.
     '''
 
-    datas = "%016.x" %(extPANID)
-    Domoticz.Log("set ExtendedPANID - %16.x "\
+    datas = "%016x" %extPANID
+    Domoticz.Log("set ExtendedPANID - %016x "\
             %( extPANID) )
+    Domoticz.Log("setExtendedPANID - datas: %s" %datas)
     sendZigateCmd(self, "0020", datas )
 
 def leaveMgtReJoin( self, saddr, ieee, rejoin=True):

--- a/plugin.py
+++ b/plugin.py
@@ -85,7 +85,7 @@ import queue
 import sys
 
 from Modules.tools import removeDeviceInList
-from Modules.output import sendZigateCmd, removeZigateDevice, ZigatePermitToJoin, start_Zigate
+from Modules.output import sendZigateCmd, removeZigateDevice, ZigatePermitToJoin, start_Zigate, setExtendedPANID
 from Modules.input import ZigateRead
 from Modules.heartbeat import processListOfDevices
 from Modules.database import importDeviceConf, LoadDeviceList, checkListOfDevice2Devices, checkListOfDevice2Devices, WriteDeviceList
@@ -348,6 +348,10 @@ class BasePlugin:
                 self.domoticzdb_Hardware.disableErasePDM()
             Domoticz.Status("Erase Zigate PDM")
             sendZigateCmd(self, "0012", "")
+            if self.pluginconf.extendedPANID is not None:
+                Domoticz.Status("ZigateConf - Setting extPANID : 0x%016x" %( self.pluginconf.extendedPANID) )
+                setExtendedPANID(self, self.pluginconf.extendedPANID)
+
             start_Zigate( self )
 
         if Parameters["Mode4"] == "True": # Software Non-Factory Reseet

--- a/plugin.py
+++ b/plugin.py
@@ -85,7 +85,7 @@ import queue
 import sys
 
 from Modules.tools import removeDeviceInList
-from Modules.output import sendZigateCmd, ZigateConf, ZigateConf_light, removeZigateDevice, ZigatePermitToJoin, start_Zigate
+from Modules.output import sendZigateCmd, removeZigateDevice, ZigatePermitToJoin, start_Zigate
 from Modules.input import ZigateRead
 from Modules.heartbeat import processListOfDevices
 from Modules.database import importDeviceConf, LoadDeviceList, checkListOfDevice2Devices, checkListOfDevice2Devices, WriteDeviceList


### PR DESCRIPTION
Implement #399 

However it looks like the 0x0020 command doesn't behave always the same.

Current implementation in the plugin is to have the set of ExtendedPANID only after an Erase PDM. Which makes some sense.


https://github.com/fairecasoimeme/ZiGate/issues/189