### PR TITLE
Device changing short id during provisionning

### DIFF
--- a/Modules/input.py
+++ b/Modules/input.py
@@ -2193,7 +2193,7 @@ def Decode004D(self, Devices, MsgData, MsgRSSI) : # Reception Device announce
         if IEEEExist( self, MsgIEEE ):
             # we are getting a dupplicate. Most-likely the Device is existing and we have to reconnect.
             if not DeviceExist(self, Devices, MsgSrcAddr,MsgIEEE):
-                loggingPairing( self, 'Error', "Decode004d - Paranoia .... NwkID: %s, IEEE: % -> %s " 
+                loggingPairing( self, 'Error', "Decode004d - Paranoia .... NwkID: %s, IEEE: %s -> %s " 
                         %(MsgSrcAddr, MsgIEEE, str(self.ListOfDevices[MsgSrcAddr])))
                 return
 

--- a/Modules/input.py
+++ b/Modules/input.py
@@ -2045,9 +2045,11 @@ def Decode004D(self, Devices, MsgData, MsgRSSI) : # Reception Device announce
             '99': '0x99 - Unknown value received.'
             }
 
-    if MsgSrcAddr in self.ListOfDevices:
+    if MsgIEEE in self.IEEE2NWK and MsgSrcAddr in self.ListOfDevices:
+        # In case we receive a Device Annoucement we are alreday doing the provisioning.
+        # Same IEEE and same Short Address.
+        # We will drop the message, as there is no reason to process it.
         if self.ListOfDevices[MsgSrcAddr]['Status'] in ( '004d', '0045', '0043', '8045', '8043'):
-            # Let's skip it has this is a duplicate message from the device
             loggingInput( self, 'Debug', "Decode004D - Already known device %s with status: %s" %( MsgSrcAddr, self.ListOfDevices[MsgSrcAddr]['Status']), MsgSrcAddr)
             return
 
@@ -2175,6 +2177,7 @@ def Decode004D(self, Devices, MsgData, MsgRSSI) : # Reception Device announce
         # New device comming. The IEEE is not known
         loggingInput( self, 'Debug', "Decode004D - New Device %s %s" %(MsgSrcAddr, MsgIEEE), MsgSrcAddr)
 
+        # I wonder if this code makes sense ? ( PP 02/05/2020 ), This should not happen!
         if MsgIEEE in self.IEEE2NWK :
             Domoticz.Error("Decode004d - New Device %s %s already exist in IEEE2NWK" %(MsgSrcAddr, MsgIEEE))
             loggingPairing( self, 'Debug', "Decode004d - self.IEEE2NWK[MsgIEEE] = %s with Status: %s" 
@@ -2183,7 +2186,10 @@ def Decode004D(self, Devices, MsgData, MsgRSSI) : # Reception Device announce
                 loggingInput( self, 'Debug', "Decode004d - receiving a new Device Announced for a device in processing, drop it",MsgSrcAddr)
             return
 
+        # 1- Create the entry in IEEE - 
         self.IEEE2NWK[MsgIEEE] = MsgSrcAddr
+
+        # This code should not happen !( PP 02/05/2020 )
         if IEEEExist( self, MsgIEEE ):
             # we are getting a dupplicate. Most-likely the Device is existing and we have to reconnect.
             if not DeviceExist(self, Devices, MsgSrcAddr,MsgIEEE):
@@ -2191,7 +2197,7 @@ def Decode004D(self, Devices, MsgData, MsgRSSI) : # Reception Device announce
                         %(MsgSrcAddr, MsgIEEE, str(self.ListOfDevices[MsgSrcAddr])))
                 return
 
-        # 1- Create the Data Structutre
+        # 2- Create the Data Structutre
         initDeviceInList(self, MsgSrcAddr)
         loggingPairing( self, 'Debug',"Decode004d - Looks like it is a new device sent by Zigate")
         self.CommiSSionning = True
@@ -2214,7 +2220,7 @@ def Decode004D(self, Devices, MsgData, MsgRSSI) : # Reception Device announce
             self.DevicesInPairingMode.append( MsgSrcAddr )
         loggingPairing( self, 'Log',"--> %s" %str(self.DevicesInPairingMode))
 
-        # 2- Store the Pairing info if needed
+        # 3- Store the Pairing info if needed
         if self.pluginconf.pluginConf['capturePairingInfos']:
             if MsgSrcAddr not in self.DiscoveryDevices:
                 self.DiscoveryDevices[MsgSrcAddr] = {}
@@ -2225,7 +2231,7 @@ def Decode004D(self, Devices, MsgData, MsgRSSI) : # Reception Device announce
             self.DiscoveryDevices[MsgSrcAddr]['MacCapa'] = MsgMacCapa
             self.DiscoveryDevices[MsgSrcAddr]['Decode-MacCapa'] = deviceMacCapa
 
-        # 3- We will request immediatly the List of EndPoints
+        # 4- We will request immediatly the List of EndPoints
         PREFIX_IEEE_XIAOMI = '00158d000'
         if MsgIEEE[0:len(PREFIX_IEEE_XIAOMI)] == PREFIX_IEEE_XIAOMI:
             ReadAttributeRequest_0000(self, MsgSrcAddr, fullScope=False ) # In order to request Model Name

--- a/Modules/tools.py
+++ b/Modules/tools.py
@@ -147,7 +147,7 @@ def DeviceExist(self, Devices, lookupNwkId , lookupIEEE = ''):
 
             return False
 
-        elif self.ListOfDevices[ exitsingNwkId ]['Status'] in ( '004d', '0045', '0043', '8045', '8043'):
+        elif self.ListOfDevices[ exitsingNwkId ]['Status'] in ( '004d', '0045', '0043', '8045', '8043', 'UNKNOW'):
             # We are in the discovery/provisioning process,
             # and the device got a new Short Id
             # we need to restart from the begiging and remove all existing datastructutre.

--- a/Modules/tools.py
+++ b/Modules/tools.py
@@ -112,7 +112,8 @@ def DeviceExist(self, Devices, lookupNwkId , lookupIEEE = ''):
             if self.ListOfDevices[lookupNwkId]['Status'] != 'UNKNOWN':
                 found = True
 
-    # 2- We might have found it with the lookupNwkId   
+    # 2- We might have found it with the lookupNwkId 
+    # If we didnt find it, we should check if this is not a new ShortId  
     if lookupIEEE:
         if lookupIEEE not in self.IEEE2NWK:
             # Not found
@@ -122,24 +123,46 @@ def DeviceExist(self, Devices, lookupNwkId , lookupIEEE = ''):
         exitsingNwkId = self.IEEE2NWK[ lookupIEEE ]
         if exitsingNwkId == lookupNwkId:
             # Everything fine, we have found it
-            found = True
+            # and this is the same ShortId as the one existing
+            return True
 
         elif exitsingNwkId not in self.ListOfDevices:
+            # Should not happen
             # We have an entry in IEEE2NWK, but no corresponding
             # in ListOfDevices !!
             # Let's clenup
             del self.IEEE2NWK[ lookupIEEE ]
-            found = False
+            return False
 
         elif 'Status' not in self.ListOfDevices[ exitsingNwkId ]:
+            # Should not happen
             # That seems not correct
             # We might have to do some cleanup here !
-            found = False
+            # Cleanup
+            # Delete the entry in IEEE2NWK as it will be recreated in Decode004d
+            del self.IEEE2NWK[ lookupIEEE ]
 
-        elif self.ListOfDevices[ exitsingNwkId ]['Status'] not in ( 'inDB' , 'Left', 'Leave'):
-            # That seems not correct
-            # Could be under Creation
-            found = False
+            # Delete the all Data Structure
+            del self.ListOfDevices[ exitsingNwkId ]
+
+            return False
+
+        elif self.ListOfDevices[ exitsingNwkId ]['Status'] in ( '004d', '0045', '0043', '8045', '8043'):
+            # We are in the discovery/provisioning process,
+            # and the device got a new Short Id
+            # we need to restart from the begiging and remove all existing datastructutre.
+            # In case we receive asynchronously messages (which should be possible), they must be
+            # droped in the corresponding Decodexxx function
+            Domoticz.Status("DeviceExist - Device %s changed its ShortId: from %s to %s during provisioing. Restarting !" 
+                %( lookupIEEE, exitsingNwkId , lookupNwkId ))
+
+            # Delete the entry in IEEE2NWK as it will be recreated in Decode004d
+            del self.IEEE2NWK[ lookupIEEE ]
+
+            # Delete the all Data Structure
+            del self.ListOfDevices[ exitsingNwkId ]
+
+            return False
 
         else:
             # At that stage, we have found an entry for the IEEE, but doesn't match


### PR DESCRIPTION
It could happen during provisioning that the ShortId change.

From @badzz investigation, this could happen when the authentication is not finalized. We may wonder why we get a Device Announcement while authentication is not in place.

The PR is addressing those and is also doing some changes in order to get the code a bit more resilient to that type of aspect.

Related : #543
