### PR TITLE
Second part for Alarm on BMS wiser.

### DIFF
--- a/Modules/command.py
+++ b/Modules/command.py
@@ -331,11 +331,11 @@ def mgtCommand( self, Devices, Unit, Command, Level, Color ) :
             if 'Schneider Wiser' not in self.ListOfDevices[NWKID]:
                 self.ListOfDevices[NWKID]['Schneider Wiser'] ={}
             if Level in CONTRACT_MODE:
-                loggingCommand( self, 'Log', "mgtCommand : -----> Contract Power : %s - %s" %(Level, CONTRACT_MODE[ Level ]), NWKID)
+                loggingCommand( self, 'Log', "mgtCommand : -----> Contract Power : %s - %s KVA" %(Level, CONTRACT_MODE[ Level ]), NWKID)
                 if 'Model' in self.ListOfDevices[NWKID]:
                     if self.ListOfDevices[NWKID]['Model'] == 'EH-ZB-BMS':
                         self.ListOfDevices[NWKID]['Schneider Wiser']['Contract Power'] = CONTRACT_MODE[ Level ]
-                        schneider_set_contract( self, NWKID,  CONTRACT_MODE[ Level ] )
+                        schneider_set_contract( self, NWKID, EPout, CONTRACT_MODE[ Level ] )
                         UpdateDevice_v2(self, Devices, Unit, int(Level)//10, Level,BatteryLevel, SignalLevel,  ForceUpdate_=forceUpdateDev)
             return
 

--- a/Modules/domoticz.py
+++ b/Modules/domoticz.py
@@ -296,7 +296,7 @@ def CreateDomoDevice(self, Devices, NWKID):
 
             # 5 Selector , OffHidden, Style 0 (command)
             if t in ('ContractPower', ):
-                Options = createSwitchSelector( 4, DeviceType = t, OffHidden = True, SelectorStyle = 0 )
+                Options = createSwitchSelector( 6, DeviceType = t, OffHidden = True, SelectorStyle = 0 )
                 createDomoticzWidget( self, Devices, NWKID, DeviceID_IEEE, Ep, t, widgetOptions = Options)
                 loggingWidget( self, "Debug", "CreateDomoDevice - t: %s in ContractPower ..." %(t), NWKID)
 

--- a/Modules/output.py
+++ b/Modules/output.py
@@ -21,7 +21,7 @@ from time import time
 from Modules.zigateConsts import ZLL_DEVICES, MAX_LOAD_ZIGATE, CLUSTERS_LIST, MAX_READATTRIBUTES_REQ, LEGRAND_REMOTES, ADDRESS_MODE, CFG_RPT_ATTRIBUTESbyCLUSTERS, SIZE_DATA_TYPE, ZIGATE_EP
 from Modules.tools import getClusterListforEP, mainPoweredDevice
 from Modules.logging import loggingOutput
-from Modules.schneider_wiser import schneider_setpoint, schneider_EHZBRTS_thermoMode
+from Modules.schneider_wiser import schneider_setpoint
 
 def ZigatePermitToJoin( self, permit ):
 
@@ -1406,7 +1406,7 @@ def thermostat_Setpoint( self, key, setpoint):
 
             elif self.ListOfDevices[key]['Model'] in ( 'EH-ZB-RTS', 'EH-ZB-HACT', 'EH-ZB-VACT' ):
                 loggingOutput( self, 'Debug', "thermostat_Setpoint - calling Schneider for %s with value %s" %(key,setpoint), nwkid=key)
-                schneider_setpoint( self, key, setpoint)
+                schneider_setpoint(self, key, setpoint)
                 return
 
     loggingOutput( self, 'Debug', "thermostat_Setpoint - standard for %s with value %s" %(key,setpoint), nwkid=key)

--- a/Modules/widgets.py
+++ b/Modules/widgets.py
@@ -328,10 +328,10 @@ SWITCH_LVL_MATRIX = {
         }
     },
 
-    "ContractPower": {
-        "LevelNames": "3KVA|6KVA|9KVA|12KVA|15KVA",
+    'ContractPower': {
+        "LevelNames": "Off|3KVA|6KVA|9KVA|12KVA|15KVA",
         "Language": {
-            "fr-FR": {"LevelNames": "3KVA|6KVA|9KVA|12KVA|15KVA"}
+            "fr-FR": {"LevelNames": "Off|3KVA|6KVA|9KVA|12KVA|15KVA"}
         }
     },
 


### PR DESCRIPTION
We need to speed up reporting when alarm is on, hence I had to import configurereporting and do avoid cyclic import error, I changed the import on other modules
Moreover, I had to hard code the endpoint for the device as I could not find the right one as many endpoint have the same clusterids
To be continued