### PR TITLE
Small quick fix

### DIFF
--- a/Classes/NetworkMap.py
+++ b/Classes/NetworkMap.py
@@ -128,7 +128,6 @@ class NetworkMap():
 
         return
 
-
     def _initNeighboursTableEntry( self, nwkid):
 
         self.logging( 'Debug', "_initNeighboursTableEntry - %s" %nwkid)
@@ -146,7 +145,6 @@ class NetworkMap():
             for entry in self.Neighbours[ nwkid ]['Neighbours']:
                 self.logging( 'Debug', "---> Neighbour %s ( %s )" %( entry, self.Neighbours[ nwkid ]['Neighbours'][entry]['_relationshp']))
         self.logging( 'Debug', "")
-
 
     def LQIreq(self, nwkid='0000'):
         """
@@ -208,7 +206,6 @@ class NetworkMap():
         self.ZigateComm.sendData( "004E",datas)  
 
         return
-
 
     def start_scan(self):
 
@@ -277,6 +274,14 @@ class NetworkMap():
 
     def finish_scan( self ):
 
+        def storeLQIforEndDevice( self, child, router, lqi):
+            if child not in self.ListOfDevices:
+                return
+            if 'LQI' not in self.ListOfDevices[ child ]:
+                self.ListOfDevices[ child ]['LQI'] = {}
+            self.ListOfDevices[ child ]['LQI'][ nwkid ] = lqi
+
+
         # Write the report onto file
         Domoticz.Status("Network Topology report")
         Domoticz.Status("------------------------------------------------------------------------------------------")
@@ -333,6 +338,8 @@ class NetworkMap():
 
                     LOD_Neighbours['Devices'].append( element )
 
+                    storeLQIforEndDevice( self, child, nwkid, int(self.Neighbours[nwkid]['Neighbours'][child]['_lnkqty'],16) )
+
             self.ListOfDevices[nwkid]['Neighbours'].append ( LOD_Neighbours )
 
         Domoticz.Status("--")
@@ -367,7 +374,6 @@ class NetworkMap():
             #self.adminWidgets.updateNotificationWidget( Devices, 'A new LQI report is available')
         else:
             Domoticz.Error("LQI:Unable to get access to directory %s, please check PluginConf.txt" %(self.pluginconf.pluginConf['pluginReports']))
-
 
     def LQIresp(self, MsgData):
 

--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -90,6 +90,7 @@ SETTINGS = {
         'resetConfigureReporting':       { 'type':'bool', 'default':0 , 'current': None, 'restart':True , 'hidden':False, 'Advanced':True},
         'resetReadAttributes':           { 'type':'bool', 'default':0 , 'current': None, 'restart':True  , 'hidden':False, 'Advanced':True},
         'resetMotiondelay':              { 'type':'int', 'default':30 , 'current': None, 'restart':False , 'hidden':False, 'Advanced':False},
+        'resetSwitchSelectorPushButton': { 'type':'int', 'default':0 , 'current': None, 'restart':False , 'hidden':False, 'Advanced':False},
         'allowGroupMembership':          { 'type':'bool', 'default':1 , 'current': None, 'restart':True  , 'hidden':False, 'Advanced':True},
         'doUnbindBind':                  { 'type':'bool', 'default':0 , 'current': None, 'restart':False , 'hidden':False, 'Advanced':True},
         'allowReBindingClusters':        { 'type':'bool', 'default':1 , 'current': None, 'restart':False , 'hidden':False, 'Advanced':True}

--- a/Modules/domoTools.py
+++ b/Modules/domoTools.py
@@ -118,33 +118,25 @@ def ResetDevice(self, Devices, ClusterType, HbCount):
         Reset all Devices from the ClusterType Motion after 30s
     '''
     def resetMotion( self, Devices, NwkId, WidgetType, unit, SignalLevel, BatteryLvl, now, lastupdate, TimedOut ):
-
         if Devices[unit].nValue == 0 and Devices[unit].sValue == "Off":
             # Nothing to Reset
             return
-
         if self.domoticzdb_DeviceStatus:
             from Classes.DomoticzDB import DomoticzDB_DeviceStatus
             # Let's check if we have a Device TimeOut specified by end user
             if self.domoticzdb_DeviceStatus.retreiveTimeOut_Motion( Devices[unit].ID) > 0:
                 return
-
-
-
         if (now - lastupdate) >= TimedOut:
-            loggingWidget( self, "Log", "Last update of the devices %s %s was %s ago" %( unit, WidgetType, (now - lastupdate)), NwkId)
-            loggingWidget( self, "Log", "Last update of the devices " + str(unit) + " was : " + str(lastupdate) + " current is : " + str(
-                now) + " this was : " + str(now - lastupdate) + " secondes ago", NwkId)
+            loggingWidget( self, "Debug", "Last update of the devices %s %s was %s ago" %( unit, WidgetType, (now - lastupdate)), NwkId)
             UpdateDevice_v2(self, Devices, unit, 0, "Off", BatteryLvl, SignalLevel)
 
     def resetSwitchSelectorPushButton( self, Devices, NwkId, WidgetType, unit, SignalLevel, BatteryLvl, now, lastupdate, TimedOut ):
-
         if Devices[unit].nValue == 0:
             return
-        Domoticz.Log("Unit: %s nValue: %s sValue: %s" %( unit, Devices[unit].nValue ,Devices[unit].sValue))
         if (now - lastupdate) >= TimedOut: 
-            loggingWidget( self, "Log", "Last update of the devices %s WidgetType: %s was %s ago" %( unit, WidgetType, (now - lastupdate)), NwkId) 
+            loggingWidget( self, "Debug", "Last update of the devices %s WidgetType: %s was %s ago" %( unit, WidgetType, (now - lastupdate)), NwkId) 
             UpdateDevice_v2(self, Devices, unit, 0, Devices[unit].sValue , BatteryLvl, SignalLevel)
+
 
     #Begining
     now = time.time()
@@ -186,9 +178,6 @@ def ResetDevice(self, Devices, ClusterType, HbCount):
             if 'ForceUpdate' in SWITCH_LVL_MATRIX[ WidgetType ]:
                 if SWITCH_LVL_MATRIX[ WidgetType ]['ForceUpdate']:
                     resetSwitchSelectorPushButton( self, Devices, NWKID, WidgetType, unit, SignalLevel, BatteryLvl, now, LUpdate , TimedOutSwitchButton)
-
-
-
 
 def UpdateDevice_v2(self, Devices, Unit, nValue, sValue, BatteryLvl, SignalLvl, Color_='', ForceUpdate_=False):
 

--- a/Modules/domoTools.py
+++ b/Modules/domoTools.py
@@ -117,28 +117,55 @@ def ResetDevice(self, Devices, ClusterType, HbCount):
     '''
         Reset all Devices from the ClusterType Motion after 30s
     '''
+    def resetMotion( self, Devices, NwkId, WidgetType, unit, SignalLevel, BatteryLvl, now, lastupdate, TimedOut ):
 
-    for unit in Devices:
         if Devices[unit].nValue == 0 and Devices[unit].sValue == "Off":
             # Nothing to Reset
-            continue
+            return
 
-        LUpdate = Devices[unit].LastUpdate
-        _tmpDeviceID_IEEE = Devices[unit].DeviceID
-        if _tmpDeviceID_IEEE not in self.IEEE2NWK:
+        if self.domoticzdb_DeviceStatus:
+            from Classes.DomoticzDB import DomoticzDB_DeviceStatus
+            # Let's check if we have a Device TimeOut specified by end user
+            if self.domoticzdb_DeviceStatus.retreiveTimeOut_Motion( Devices[unit].ID) > 0:
+                return
+
+
+
+        if (now - lastupdate) >= TimedOut:
+            loggingWidget( self, "Log", "Last update of the devices %s %s was %s ago" %( unit, WidgetType, (now - lastupdate)), NwkId)
+            loggingWidget( self, "Log", "Last update of the devices " + str(unit) + " was : " + str(lastupdate) + " current is : " + str(
+                now) + " this was : " + str(now - lastupdate) + " secondes ago", NwkId)
+            UpdateDevice_v2(self, Devices, unit, 0, "Off", BatteryLvl, SignalLevel)
+
+    def resetSwitchSelectorPushButton( self, Devices, NwkId, WidgetType, unit, SignalLevel, BatteryLvl, now, lastupdate, TimedOut ):
+
+        if Devices[unit].nValue == 0:
+            return
+        Domoticz.Log("Unit: %s nValue: %s sValue: %s" %( unit, Devices[unit].nValue ,Devices[unit].sValue))
+        if (now - lastupdate) >= TimedOut: 
+            loggingWidget( self, "Log", "Last update of the devices %s WidgetType: %s was %s ago" %( unit, WidgetType, (now - lastupdate)), NwkId) 
+            UpdateDevice_v2(self, Devices, unit, 0, Devices[unit].sValue , BatteryLvl, SignalLevel)
+
+    #Begining
+    now = time.time()
+    TimedOutMotion = self.pluginconf.pluginConf['resetMotiondelay']
+    TimedOutSwitchButton = self.pluginconf.pluginConf['resetSwitchSelectorPushButton']
+    for unit in Devices:
+
+        Ieee = Devices[unit].DeviceID
+        if Ieee not in self.IEEE2NWK:
             # Unknown !
             continue
 
+        LUpdate = Devices[unit].LastUpdate
         try:
             LUpdate = time.mktime(time.strptime(LUpdate, "%Y-%m-%d %H:%M:%S"))
         except:
             Domoticz.Error("Something wrong to decode Domoticz LastUpdate %s" %LUpdate)
             break
 
-        current = time.time()
-
         # Look for the corresponding Widget
-        NWKID = self.IEEE2NWK[_tmpDeviceID_IEEE]
+        NWKID = self.IEEE2NWK[Ieee]
 
         if NWKID not in self.ListOfDevices:
             Domoticz.Error("ResetDevice " + str(NWKID) + " not found in " + str(self.ListOfDevices))
@@ -147,31 +174,21 @@ def ResetDevice(self, Devices, ClusterType, HbCount):
         ID = Devices[unit].ID
         WidgetType = ''        
         WidgetType = WidgetForDeviceId( self, NWKID, ID)
-
-        if WidgetType not in ('Motion', 'Vibration'):
+        if WidgetType == '':
             continue
-
-        if self.domoticzdb_DeviceStatus:
-            from Classes.DomoticzDB import DomoticzDB_DeviceStatus
-
-            # Let's check if we have a Device TimeOut specified by end user
-            if self.domoticzdb_DeviceStatus.retreiveTimeOut_Motion( Devices[unit].ID) > 0:
-                continue
 
         SignalLevel, BatteryLvl = RetreiveSignalLvlBattery( self, NWKID)
 
-        _timeout = self.pluginconf.pluginConf['resetMotiondelay']
-        #resetMotionDelay = 0
-        #if self.domoticzdb_DeviceStatus:
-        #    from Classes.DomoticzDB import DomoticzDB_DeviceStatus
-        #    resetMotionDelay = round(self.domoticzdb_DeviceStatus.retreiveTimeOut_Motion( Devices[unit].ID),1)
-        #if resetMotionDelay > 0:
-        #    _timeout = resetMotionDelay
+        if WidgetType in ('Motion', 'Vibration'):
+            resetMotion( self, Devices, NWKID, WidgetType, unit, SignalLevel, BatteryLvl, now, LUpdate, TimedOutMotion)
 
-        if (current - LUpdate) >= _timeout: 
-            loggingWidget( self, "Debug", "Last update of the devices " + str(unit) + " was : " + str(LUpdate) + " current is : " + str(
-                current) + " this was : " + str(current - LUpdate) + " secondes ago", NWKID)
-            UpdateDevice_v2(self, Devices, unit, 0, "Off", BatteryLvl, SignalLevel)
+        elif TimedOutSwitchButton and WidgetType in SWITCH_LVL_MATRIX:
+            if 'ForceUpdate' in SWITCH_LVL_MATRIX[ WidgetType ]:
+                if SWITCH_LVL_MATRIX[ WidgetType ]['ForceUpdate']:
+                    resetSwitchSelectorPushButton( self, Devices, NWKID, WidgetType, unit, SignalLevel, BatteryLvl, now, LUpdate , TimedOutSwitchButton)
+
+
+
 
 def UpdateDevice_v2(self, Devices, Unit, nValue, sValue, BatteryLvl, SignalLvl, Color_='', ForceUpdate_=False):
 


### PR DESCRIPTION
Address the problem created by the Domoticz issue: 
https://github.com/domoticz/domoticz/issues/4143 
and implement a kind of automatic reset for Switch Selector which behave as a Push Button.

New parameter is introduced `resetSwitchSelectorPushButton`.
Default is 0 and this means disabled
When > 1 this mean that Switch Selector Push Button will go Off after this amount of seconds. (do consider that is done only every 5s .

WARNING:
It will trigger an event in the Device Log as well as an event to dzVent (with nValue set to 0 )

![Screenshot 2020-06-01 at 11 15 55](https://user-images.githubusercontent.com/8291674/83394687-4818f200-a3f9-11ea-947a-c8593788b436.png)
