### PR TITLE
force Widget log in case of push button

### DIFF
--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -91,6 +91,7 @@ SETTINGS = {
         'resetReadAttributes':           { 'type':'bool', 'default':0 , 'current': None, 'restart':True  , 'hidden':False, 'Advanced':True},
         'resetMotiondelay':              { 'type':'int', 'default':30 , 'current': None, 'restart':False , 'hidden':False, 'Advanced':False},
         'resetSwitchSelectorPushButton': { 'type':'int', 'default':0 , 'current': None, 'restart':False , 'hidden':False, 'Advanced':False},
+        'forceSwitchSelectorPushButton': { 'type':'bool', 'default':0 , 'current': None, 'restart':False , 'hidden':False, 'Advanced':False},
         'allowGroupMembership':          { 'type':'bool', 'default':1 , 'current': None, 'restart':True  , 'hidden':False, 'Advanced':True},
         'doUnbindBind':                  { 'type':'bool', 'default':0 , 'current': None, 'restart':False , 'hidden':False, 'Advanced':True},
         'allowReBindingClusters':        { 'type':'bool', 'default':1 , 'current': None, 'restart':False , 'hidden':False, 'Advanced':True}

--- a/Modules/domoTools.py
+++ b/Modules/domoTools.py
@@ -206,6 +206,16 @@ def UpdateDevice_v2(self, Devices, Unit, nValue, sValue, BatteryLvl, SignalLvl, 
         Devices[Unit].BatteryLevel != int(BatteryLvl) or \
         Devices[Unit].TimedOut:
 
+        if self.pluginconf.pluginConf['forceSwitchSelectorPushButton'] and ForceUpdate_:
+            if (Devices[Unit].nValue == int(nValue)) and  (Devices[Unit].sValue == sValue):
+                # Due to new version of Domoticz which do not log in case we Update the same value
+                LevelOffHidden = Devices[Unit].Options['LevelOffHidden']
+                nReset = 0
+                sReset = '0'
+                if LevelOffHidden == 'false':
+                    sReset = '00'
+                Devices[Unit].Update(nValue=nReset, sValue=sReset)
+
         if self.pluginconf.pluginConf['logDeviceUpdate']:
             Domoticz.Log("UpdateDevice - (%15s) %s:%s" %( Devices[Unit].Name, nValue, sValue ))
         loggingWidget( self, "Debug", "--->  [Unit: %s] %s:%s:%s %s:%s %s (%15s)" %( Unit, nValue, sValue, Color_, BatteryLvl, SignalLvl, ForceUpdate_, Devices[Unit].Name), self.IEEE2NWK[Devices[Unit].DeviceID])


### PR DESCRIPTION
In relation to the issue in Domoticz
https://github.com/domoticz/domoticz/issues/4143

giving an extra possibility to end user to force update in logs.
forceSwitchSelectorPushButton

![Screenshot 2020-06-01 at 17 56 08](https://user-images.githubusercontent.com/8291674/83427580-3ce1b880-a431-11ea-80cc-2ba44e87c1e4.png)
