### PR TITLE
Group errors from the same start time

### DIFF
--- a/Classes/LoggingManagement.py
+++ b/Classes/LoggingManagement.py
@@ -28,6 +28,20 @@ class LoggingManagement:
         self.permitTojoin = permitTojoin
         self.FirmwareVersion = None
         self.FirmwareMajorVersion = None
+        self._startTime = int(time.time())
+        
+        
+        
+    def loggingUpdateFirmware(self, FirmwareVersion, FirmwareMajorVersion):
+        self.FirmwareVersion = FirmwareVersion
+        self.FirmwareMajorVersion = FirmwareMajorVersion
+        if self.LogErrorHistory:
+            if self.LogErrorHistory['LastLog']:
+                if 'TimeStamp' in self.LogErrorHistory[str(self.LogErrorHistory['LastLog'])]:
+                    if self.LogErrorHistory[str(self.LogErrorHistory['LastLog'])]['TimeStamp'] == self._startTime:
+                        self.LogErrorHistory[str(self.LogErrorHistory['LastLog'])]['FirmwareVersion'] = FirmwareVersion
+                        self.LogErrorHistory[str(self.LogErrorHistory['LastLog'])]['FirmwareMajorVersion'] = FirmwareMajorVersion
+
         
     def openLogFile( self ):
 
@@ -124,13 +138,45 @@ class LoggingManagement:
     def loggingError(self, module, message, nwkid, context):
         Domoticz.Error(message)
 
+        #Log empty
         if not self.LogErrorHistory or 'LastLog' not in self.LogErrorHistory:
             self.LogErrorHistory['LastLog'] = 0
-            self.LogErrorHistory['0'] = self.loggingBuildContext(module, message, nwkid, context)
+            self.LogErrorHistory['0'] = {}
+            self.LogErrorHistory['0']['LastLog'] = 0
+            self.LogErrorHistory['0']['TimeStamp'] = self._startTime
+            self.LogErrorHistory['0']['FirmwareVersion'] = self.FirmwareVersion
+            self.LogErrorHistory['0']['FirmwareMajorVersion'] = self.FirmwareMajorVersion
+            self.LogErrorHistory['0']['0'] = self.loggingBuildContext(module, message, nwkid, context)
+            self.loggingWriteErrorHistory()
+            return # log created, leaving
+        
+        #check if existing log contains plugin launch time
+        if 'TimeStamp' in self.LogErrorHistory[str(self.LogErrorHistory['LastLog'])]:
+            index = self.LogErrorHistory['LastLog']
+            #check if launch time if the same, otherwise, create a new entry
+            if self.LogErrorHistory[str(index)]['TimeStamp'] != self._startTime:
+                index += 1
+        else: #compatibility with older version
+            index = self.LogErrorHistory['LastLog'] + 1
+        
+        #check if it's a new entry
+        if str(index) not in self.LogErrorHistory:
+            self.LogErrorHistory['LastLog'] += 1
+            self.LogErrorHistory[str(index)] = {}
+            self.LogErrorHistory[str(index)]['LastLog'] = 0
+            self.LogErrorHistory[str(index)]['TimeStamp'] = self._startTime
+            self.LogErrorHistory[str(index)]['FirmwareVersion'] = self.FirmwareVersion
+            self.LogErrorHistory[str(index)]['FirmwareMajorVersion'] = self.FirmwareMajorVersion
+            self.LogErrorHistory[str(index)]['0'] = self.loggingBuildContext(module, message, nwkid, context)
         else:
-            self.LogErrorHistory['LastLog'] = int(self.LogErrorHistory['LastLog']) + 1
-            self.LogErrorHistory[str(self.LogErrorHistory['LastLog'])] = self.loggingBuildContext( module, message, nwkid, context)
-            if len(self.LogErrorHistory) > 20: #log full for this module, remove older
+            self.LogErrorHistory[str(index)]['LastLog'] += 1
+            self.LogErrorHistory[str(index)][str(self.LogErrorHistory[str(index)]['LastLog'])] = self.loggingBuildContext(module, message, nwkid, context)
+            
+            if len(self.LogErrorHistory[str(index)]) > 20+4: #log full for this launch time, remove oldest
+                idx = list(self.LogErrorHistory[str(index)].keys())[4]
+                self.LogErrorHistory[str(index)].pop(idx)
+        
+        if len(self.LogErrorHistory) > 5+1: #log full, remove oldest
                 idx = list(self.LogErrorHistory.keys())[1]
                 self.LogErrorHistory.pop(idx)
 
@@ -150,11 +196,9 @@ class LoggingManagement:
                     'nwkid': nwkid,
                     'PluginHealth': _txt,
                     'message': message,
-                    'PermitToJoin': self.permitTojoin,
-                    'FirmwareVersion': self.FirmwareVersion,
-                    'FirmwareMajorVersion': self.FirmwareMajorVersion
+                    'PermitToJoin': self.permitTojoin
                 }
-        if nwkid:
+        if nwkid and nwkid in self.ListOfDevices:
             _context[ 'DeviceInfos'] = dict(self.ListOfDevices[ nwkid ])
         if context is not None:
             if isinstance(context, dict):
@@ -175,9 +219,13 @@ class LoggingManagement:
     def loggingCleaningErrorHistory( self ):
         if len(self.LogErrorHistory) > 1:
             idx = list(self.LogErrorHistory.keys())[1]
-            if time.time() - self.LogErrorHistory[idx]['Time'] > 1360800: #7 days
+            if len(self.LogErrorHistory[str(idx)]) > 4:
+                idx2 = list(self.LogErrorHistory[str(idx)].keys())[4]
+                if time.time() - self.LogErrorHistory[str(idx)][str(idx2)]['Time'] > 1360800: #7 days
+                    self.LogErrorHistory[idx].pop(idx2)
+            if len(self.LogErrorHistory[str(idx)]) == 4:
                 self.LogErrorHistory.pop(idx)
-        elif len(self.LogErrorHistory) == 1:
+        if len(self.LogErrorHistory) == 1:
             self.LogErrorHistory.clear()
 
             

--- a/Classes/LoggingManagement.py
+++ b/Classes/LoggingManagement.py
@@ -33,6 +33,8 @@ class LoggingManagement:
         
         
     def loggingUpdateFirmware(self, FirmwareVersion, FirmwareMajorVersion):
+        if self.FirmwareVersion and self.FirmwareMajorVersion:
+            return
         self.FirmwareVersion = FirmwareVersion
         self.FirmwareMajorVersion = FirmwareMajorVersion
         if self.LogErrorHistory:

--- a/Modules/input.py
+++ b/Modules/input.py
@@ -769,17 +769,15 @@ def Decode8010(self, Devices, MsgData, MsgLQI):  # Reception Version list
             str(MajorVersNum) + " - " + str(InstaVersNum)
         )
 
-
-
-
-
-        
         if self.webserver:
             self.webserver.update_firmware(self.FirmwareVersion)
 
         if self.ZigateComm:
             self.ZigateComm.update_ZiGate_Version ( self.FirmwareVersion, self.FirmwareMajorVersion)
-
+        
+        if self.log:
+            self.log.loggingUpdateFirmware( self.FirmwareVersion, self.FirmwareMajorVersion)    
+            
     self.PDMready = True
 
 


### PR DESCRIPTION
Logs are now organised from the start time information.
A new key TimeStamp contains the startime and all the errors from the same start time are gathered.
The capacity is 5 different start times and for each start time, 20 logs.