### PR TITLE
Release 5.1.004

### DIFF
--- a/Conf/Certified/Philips/LTG002.json
+++ b/Conf/Certified/Philips/LTG002.json
@@ -1,0 +1,40 @@
+{
+	"Ep":{
+		"0b": {
+			"0000": "", 
+			"0003": "", 
+			"0004": "",
+			"0005": "", 
+			"0006": "", 
+			"0008": "", 
+			"0300": "", 
+			"fc02": "",
+			"1000": "", 
+			"0019": "", 
+			"Type": "ColorControlWW"
+		},
+		"f2": {
+			"0021": "", 
+			"Type": ""
+		}
+	},
+	"Type":"",
+	"NickName":"",
+        "ClusterToBind": [ "0006", "0008", "0019" ],
+        "ConfigureReporting": {
+                "0006": {"Attributes": { "0000": {"DataType": "10", "MinInterval":"0001", "MaxInterval":"012C", "TimeOut":"0000","Change":"01"}}},
+                "0008": {"Attributes": { "0000": {"DataType": "20", "MinInterval":"0005", "MaxInterval":"012C", "TimeOut":"0000","Change":"05"}}}
+        },
+  	"ReadAttributes": {
+        	 "0000": [ "0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "4000" ] ,
+		 "0006": [ "0000" , "4000", "4001", "4002", "4003" ],
+		 "0008": [ "0000" ],
+		 "0300": [ "0003", "0004", "0007", "0008" ]
+	},
+	"Param": {
+		"PowerOnAfterOffOn": 255,
+		"OnOffPollingFreq": 300,
+		"fadingOff": 0,  
+		"moveToColourTemp": 0,
+		"moveToLevel": 0	}
+}

--- a/Modules/heartbeat.py
+++ b/Modules/heartbeat.py
@@ -60,8 +60,8 @@ def attributeDiscovery( self, NwkId ):
         rescheduleAction = False
         # If Attributes not yet discovered, let's do it
 
-        #if 'ConfigSource' not in self.ListOfDevices[NwkId]:
-        #    return False
+        if 'ConfigSource' not in self.ListOfDevices[NwkId]:
+            return False
 
         if 'ConfigSource' in self.ListOfDevices[NwkId] and self.ListOfDevices[NwkId]['ConfigSource'] == 'DeviceConf':
             return False

--- a/Modules/heartbeat.py
+++ b/Modules/heartbeat.py
@@ -430,7 +430,7 @@ def processKnownDevices( self, Devices, NWKID ):
         rescheduleAction = ( rescheduleAction or schneiderRenforceent(self, NWKID))
 
     # Do Attribute Disocvery if needed
-    if not enabledEndDevicePolling and (( intHB % 1800) == 0):
+    if _mainPowered and not enabledEndDevicePolling and (( intHB % 1800) == 0):
         rescheduleAction = ( rescheduleAction or attributeDiscovery( self, NWKID ) )
 
     # If corresponding Attributes not present, let's do a Request Node Description

--- a/Modules/input.py
+++ b/Modules/input.py
@@ -1844,6 +1844,11 @@ def Decode8045(self, Devices, MsgData, MsgLQI):  # Reception Active endpoint res
                 "-", MsgDataShAddr, tmpEp, self.ListOfDevices[MsgDataShAddr]["Status"]), )
     self.ListOfDevices[MsgDataShAddr]["NbEp"] = str(int(MsgDataEpCount, 16))  # Store the number of EPs
 
+    # Request the Basic ReadAttribute before requesting the Node Descriptor
+    if "Model" not in self.ListOfDevices[MsgDataShAddr] or self.ListOfDevices[MsgDataShAddr]["Model"] in ("", {}):
+        self.log.logging(  "Input", "Log", "[%s] NEW OBJECT: %s Request Model Name" % ("-", MsgDataShAddr) )
+        ReadAttributeRequest_0000( self, MsgDataShAddr, fullScope=False )  # In order to request Model Name
+
     for iterEp in self.ListOfDevices[MsgDataShAddr]["Ep"]:
         self.log.logging(  "Input", "Status", "[%s] NEW OBJECT: %s Request Simple Descriptor for Ep: %s" % (
             "-", MsgDataShAddr, iterEp), )
@@ -1852,10 +1857,6 @@ def Decode8045(self, Devices, MsgData, MsgLQI):  # Reception Active endpoint res
 
     self.ListOfDevices[MsgDataShAddr]["Heartbeat"] = "0"
     self.ListOfDevices[MsgDataShAddr]["Status"] = "0043"
-
-    if "Model" not in self.ListOfDevices[MsgDataShAddr] or self.ListOfDevices[MsgDataShAddr]["Model"] in ("", {}):
-        self.log.logging(  "Input", "Log", "[%s] NEW OBJECT: %s Request Model Name" % ("-", MsgDataShAddr) )
-        ReadAttributeRequest_0000( self, MsgDataShAddr, fullScope=False )  # In order to request Model Name
 
     self.log.logging( "Pairing", "Debug", "Decode8045 - Device : " + str(MsgDataShAddr) +
      " updated ListofDevices with " + str(self.ListOfDevices[MsgDataShAddr]["Ep"]), )

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -21,6 +21,10 @@ Release Numbering
 - Odd numbers --> Stable5
 - Even numbers  --> Beta
 
+## 19 June 2021   - 5.1.04
+- [Hardware] - Philips Hue Hue White Ambiance GU10
+- [Technical] - various fixes
+
 ## 31st May 2021  -  5.1.03
 - [Technical] - Better management of ZiGate V1 and V2
 - [Technical] - Revert Config.Reporting of End Device to a proprer rate


### PR DESCRIPTION
- Skip Attribute List discovery if ConfigSource unknown
- Do not request Attribute List for non-powered devices
- Hue White Ambiance device
- Request the Model/Manuf name just before requesting the Node Descriptor