### PR TITLE
Add MOES MS-104BZ-1 compatibility

### DIFF
--- a/Conf/Certified/Tuya/TS011F-2Gang-switches.json
+++ b/Conf/Certified/Tuya/TS011F-2Gang-switches.json
@@ -1,0 +1,34 @@
+{
+	"_comment": "Tuya 2 Gangs Switch",
+	"_version": "1.0",
+	"Ep":{
+		"01":{ 
+			"0000":"", 
+			"0004":"", 
+			"0005":"", 
+			"0006":"",
+			"000a":"",
+			"0019":"", 
+			"Type":"Switch"
+        },
+        "02":{ 
+            "0000":"", 
+            "0004":"", 
+            "0005":"", 
+            "0006":"",
+            "Type":"Switch"
+        }
+	},
+	"Type":"",
+	"ClusterToBind": [ "0000", "0006", "0019" ],
+	"ConfigureReporting": {
+		"0006": {"Attributes": { "0000": {"DataType": "10", "MinInterval":"0001", "MaxInterval":"012C", "TimeOut":"0258","Change":"01"}}}
+	},
+	"ReadAttributes": {
+		"0000": [ "0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "ffde", "fffd", "fffe", "ffe0", "ffe1", "ffe2", "ffdf" ],
+		"0006": [ "0000", "4001", "4002", "8001", "8002", "fffd" ]
+	},
+    "Param": {
+		"PowerOnAfterOffOn": 0
+	}
+}

--- a/Modules/paramDevice.py
+++ b/Modules/paramDevice.py
@@ -122,7 +122,12 @@ def param_PowerOnAfterOffOn(self, nwkid, mode):
             philips_set_poweron_after_offon_device(self, mode, nwkid)
             ReadAttributeRequest_0006_400x(self, nwkid)
 
-    elif "Model" in self.ListOfDevices[nwkid] and self.ListOfDevices[nwkid]["Model"] in ("TS0121", "TS0115"):
+    elif "Model" in self.ListOfDevices[nwkid] and self.ListOfDevices[nwkid]["Model"] in (
+        "TS0121",
+        "TS0115",
+        "TS011F-multiprise",
+        "TS011F-2Gang-switches"
+    ):
         # Tuya ( 'TS0121' BlitzWolf )
         if "01" not in self.ListOfDevices[nwkid]["Ep"]:
             return

--- a/Modules/readClusters.py
+++ b/Modules/readClusters.py
@@ -424,9 +424,13 @@ def Cluster0000(
         if modelName == "lumi.sensor_swit":
             modelName = "lumi.sensor_switch.aq3"
 
-        if modelName == "TS011F" and manufacturer_name == "_TZ3000_vzopcetz":
-            # Lidl multiprise
-            modelName = "TS011F-multiprise"
+        if modelName == "TS011F":
+            if manufacturer_name == "_TZ3000_vzopcetz":
+                # Lidl multiprise
+                modelName = "TS011F-multiprise"
+            elif manufacturer_name == "_TZ3000_pmz6mjyu":
+                # MOES MS-104BZ-1
+                modelName = "TS011F-2Gang-switches"
 
         elif modelName == "AC211":
             modelName = "AC221"


### PR DESCRIPTION
It's a 2 gang relays and default TS011F contains only one Ep/switch.