### PR TITLE
Add a semaphore per device requests

### DIFF
--- a/Classes/ZigpyTransport/Transport.py
+++ b/Classes/ZigpyTransport/Transport.py
@@ -46,6 +46,10 @@ class ZigpyTransport(object):
         
         self.permit_to_join_timer = { "Timer": None, "Duration": None}
 
+        # Semaphore per devices
+        self._concurrent_requests_semaphores_list = {}
+        self._currently_waiting_requests_list = {}  
+
         # Initialise SQN Management
         sqn_init_stack(self)
 

--- a/Classes/ZigpyTransport/Transport.py
+++ b/Classes/ZigpyTransport/Transport.py
@@ -78,15 +78,16 @@ class ZigpyTransport(object):
         self.forwarder_thread.join()
 
     def sendData(self, cmd, datas, sqn=None, highpriority=False, ackIsDisabled=False, waitForResponseIn=False, NwkId=None):
-        if self.writer_queue.qsize() > self.statistics._MaxLoad:
-            self.statistics._MaxLoad = self.writer_queue.qsize()
+        _queue = self.loadTransmit()
+        if _queue > self.statistics._MaxLoad:
+            self.statistics._MaxLoad = _queue
 
         if self.pluginconf.pluginConf["debugzigateCmd"]:
             self.log.logging(
                 "Transport",
                 "Log",
                 "sendData       - [%s] %s %s %s Queue Length: %s"
-                % (sqn, cmd, datas, NwkId, self.writer_queue.qsize()),
+                % (sqn, cmd, datas, NwkId, _queue),
             )
 
         self.log.logging("Transport", "Debug", "===> sendData - Cmd: %s Datas: %s" % (cmd, datas))

--- a/Classes/ZigpyTransport/Transport.py
+++ b/Classes/ZigpyTransport/Transport.py
@@ -115,4 +115,8 @@ class ZigpyTransport(object):
 
     def loadTransmit(self):
         # Provide the Load of the Sending Queue
-        return self.writer_queue.qsize()
+        _queue = self.writer_queue.qsize()
+        for device in self._currently_waiting_requests_list:
+            _queue += self._currently_waiting_requests_list[device]
+        return _queue
+

--- a/Classes/ZigpyTransport/zigpyThread.py
+++ b/Classes/ZigpyTransport/zigpyThread.py
@@ -390,6 +390,7 @@ async def _limit_concurrency(self, destination):
     Mainly a thin wrapper around `asyncio.Semaphore` that logs when it has to wait.
     """
     _ieee = str(destination.ieee)
+    _nwkid = destination.nwk.serialize()[::-1].hex()
 
     if _ieee not in self._concurrent_requests_semaphores_list:
         self._concurrent_requests_semaphores_list[_ieee] = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS_PER_DEVICE)
@@ -409,8 +410,8 @@ async def _limit_concurrency(self, destination):
         self.log.logging(
             "TransportZigpy",
             "Debug",
-            "Max concurrency reached, delaying requests (%s enqueued)" %
-            self._currently_waiting_requests_list[_ieee],
+            "Max concurrency reached for %s, delaying requests (%s enqueued)" %
+            (_nwkid,self._currently_waiting_requests_list[_ieee]), _nwkid,
         )
 
     try:
@@ -420,8 +421,9 @@ async def _limit_concurrency(self, destination):
                     "TransportZigpy",
                     "Debug",
                     "Previously delayed request is now running, "
-                    "delayed by %0.2f seconds"%(
-                    time.time() - start_time),
+                    "delayed by %0.2f seconds for %s"%(
+                    (time.time() - start_time),_nwkid),
+                  _nwkid,
                 ) 
             yield
     finally:

--- a/Classes/ZigpyTransport/zigpyThread.py
+++ b/Classes/ZigpyTransport/zigpyThread.py
@@ -206,6 +206,8 @@ async def dispatch_command(self, data):
         duration = data["datas"]["Duration"]
         if duration == 0xFF:
             duration = 0xFE
+        self.permit_to_join_timer["Timer"] = time.time()
+        self.permit_to_join_timer["Duration"] = duration
         await self.app.permit(time_s=duration)
     elif data["cmd"] == "SET-TX-POWER":
         await self.app.set_tx_power(data["datas"]["Param1"])


### PR DESCRIPTION
This PR allows to add a flow control per device to avoid to flood or block the send slots