### PR TITLE
Update ZLinky Cluster 0xff66 in case of alarm for excess power

### DIFF
--- a/Modules/readClusters.py
+++ b/Modules/readClusters.py
@@ -5154,12 +5154,12 @@ def Clusterff66(self, Devices, MsgSQN, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAt
             _tmpattr = "0a08"
 
         if value == 0:
-            MajDomoDevice(self, Devices, MsgSrcAddr, _tmpep, "0009", "00")
+            MajDomoDevice(self, Devices, MsgSrcAddr, _tmpep, "0009", "00|Normal", Attribute_="0005")
             return
 
         # value is equal to the Amper over the souscription
         # Issue critical alarm
-        MajDomoDevice(self, Devices, MsgSrcAddr, _tmpep, "0009", "04")
+        MajDomoDevice(self, Devices, MsgSrcAddr, _tmpep, "0009", "04|Critical", Attribute_="0005")
 
         # Isse Current on the corresponding Ampere
         MajDomoDevice(self, Devices, MsgSrcAddr, MsgSrcEp, "0b04", str(value), Attribute_=_tmpattr)

--- a/Modules/readClusters.py
+++ b/Modules/readClusters.py
@@ -4386,9 +4386,7 @@ def Cluster0b04(self, Devices, MsgSQN, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAt
             MajDomoDevice(self, Devices, MsgSrcAddr, MsgSrcEp, MsgClusterId, str(value), Attribute_=MsgAttrID)
 
             # Check if Intensity is below subscription level for oldest version (< 3)
-            if "App Version" in self.ListOfDevices[MsgSrcAddr] and int(self.ListOfDevices[MsgSrcAddr]["App Version"]) > 2:
-                # do nothing - alarm with 0xff66/0x0005 or 0xff66/0x0006:0x0008
-            else:
+            if "App Version" in self.ListOfDevices[MsgSrcAddr] and int(self.ListOfDevices[MsgSrcAddr]["App Version"]) < 3:
                 zlinky_check_alarm(self, Devices, MsgSrcAddr, MsgSrcEp, value)
 
         else:

--- a/Modules/readClusters.py
+++ b/Modules/readClusters.py
@@ -4385,8 +4385,11 @@ def Cluster0b04(self, Devices, MsgSQN, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAt
             checkAndStoreAttributeValue(self, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAttrID, value)
             MajDomoDevice(self, Devices, MsgSrcAddr, MsgSrcEp, MsgClusterId, str(value), Attribute_=MsgAttrID)
 
-            # Check if Intensity is below subscription level
-            zlinky_check_alarm(self, Devices, MsgSrcAddr, MsgSrcEp, value)
+            # Check if Intensity is below subscription level for oldest version (< 3)
+            if "App Version" in self.ListOfDevices[MsgSrcAddr] and int(self.ListOfDevices[MsgSrcAddr]["App Version"]) > 2:
+                # do nothing - alarm with 0xff66/0x0005 or 0xff66/0x0006:0x0008
+            else:
+                zlinky_check_alarm(self, Devices, MsgSrcAddr, MsgSrcEp, value)
 
         else:
             # Other type of devices
@@ -4517,7 +4520,7 @@ def zlinky_check_alarm(self, Devices, MsgSrcAddr, MsgSrcEp, value):
     flevel = (value * 100) / Isousc
     self.log.logging(
         "Cluster",
-        "Log",
+        "Debug",
         "zlinky_check_alarm - %s/%s flevel- %s %s %s" % (MsgSrcAddr, MsgSrcEp, value, Isousc, flevel),
         MsgSrcAddr,
     )
@@ -4534,7 +4537,7 @@ def zlinky_check_alarm(self, Devices, MsgSrcAddr, MsgSrcEp, value):
         )
         self.log.logging(
             "Cluster",
-            "Log",
+            "Debug",
             "zlinky_check_alarm - %s/%s Alarm-01" % (MsgSrcAddr, MsgSrcEp),
             MsgSrcAddr,
         )
@@ -4550,7 +4553,7 @@ def zlinky_check_alarm(self, Devices, MsgSrcAddr, MsgSrcEp, value):
         )
         self.log.logging(
             "Cluster",
-            "Log",
+            "Debug",
             "zlinky_check_alarm - %s/%s Alarm-02" % (MsgSrcAddr, MsgSrcEp),
             MsgSrcAddr,
         )
@@ -4558,7 +4561,7 @@ def zlinky_check_alarm(self, Devices, MsgSrcAddr, MsgSrcEp, value):
         MajDomoDevice(self, Devices, MsgSrcAddr, MsgSrcEp, "0009", "00|Normal", Attribute_="0005")
         self.log.logging(
             "Cluster",
-            "Log",
+            "Debug",
             "zlinky_check_alarm - %s/%s Alarm-03" % (MsgSrcAddr, MsgSrcEp),
             MsgSrcAddr,
         )

--- a/Modules/readClusters.py
+++ b/Modules/readClusters.py
@@ -4385,9 +4385,8 @@ def Cluster0b04(self, Devices, MsgSQN, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAt
             checkAndStoreAttributeValue(self, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAttrID, value)
             MajDomoDevice(self, Devices, MsgSrcAddr, MsgSrcEp, MsgClusterId, str(value), Attribute_=MsgAttrID)
 
-            # Check if Intensity is below subscription level for oldest version (< 3)
-            if "App Version" in self.ListOfDevices[MsgSrcAddr] and int(self.ListOfDevices[MsgSrcAddr]["App Version"]) < 3:
-                zlinky_check_alarm(self, Devices, MsgSrcAddr, MsgSrcEp, value)
+            # Check if Intensity is below subscription level
+            zlinky_check_alarm(self, Devices, MsgSrcAddr, MsgSrcEp, value)
 
         else:
             # Other type of devices


### PR DESCRIPTION
- update 0xff66/0x0005:0x0008 behavior
- remove check alarm from intensity for zlinky fw version up to 3