### PR TITLE
Require pyserial-asyncio newer than 0.5 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ crccheck==1.1
 frozenlist==1.2.0
 multidict==5.2.0
 pyserial==3.5
-pyserial-asyncio!=0.5
+pyserial-asyncio>=0.5
+pyserial-asyncio!=0.5; platform_system=="Windows"',  # 0.5 broke writesv on Windows OS
 pyusb==1.2.1
 typing-extensions==4.0.1
 voluptuous==0.12.2


### PR DESCRIPTION
pyserial-asyncio is required by recommend newer than pyserial-asyncio 0.5 (ie. 0.6 or later) as 0.5 is broken on Windows OS.

Due to known issue with pyserial-asyncio 0.5 on Windows OS -> https://github.com/pyserial/pyserial-asyncio/issues/69

https://github.com/zigbeefordomoticz/Domoticz-Zigbee/blob/stable6/requirements.txt

See example [zigpy-znp](https://github.com/zigpy/zigpy-znp) config which exclude use of pyserial-asyncio 0.5 version : 

https://github.com/zigpy/zigpy-znp/blob/dev/setup.cfg

```
install_requires =
    pyserial-asyncio; platform_system!="Windows"
    pyserial-asyncio!=0.5; platform_system=="Windows"  # 0.5 broke writes
```

Alternative is to just set  pyserial-asyncio 0.6 as the requirement, that is what Home Assistant core does for ZHA component:

https://github.com/home-assistant/core/blob/dev/requirements_all.txt#L1784

```
# homeassistant.components.serial
# homeassistant.components.zha
pyserial-asyncio==0.6
```