### PR TITLE
Update readme.md beta6 hardware compat

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,11 +113,11 @@ Your first place to get support is via the Forums.
 
 In order to provide stability and also provide more recent development, Zigbee for Domoticz plugin has the following channels
 
-* __beta6__: Current developpement branch and allow TI CCxxxx , Silicon Labs and deConz coordinators on top of ZiGate coordinators.
-* __stable6__: default branch for
-  * [ZiGate](https://zigate.fr) models knwon today,
-  * [Electrolama](https://electrolama.com/) models as well as the Texas Instrument CCxxx based coordinators,
-  * [Elelabs](https://elelabs.com/products/elelabs-usb-adapter.html) as well as the Silicon Labs based coordinators.
+* __beta6__: Current developement branch adds [ConBee/RaspBee (deconz) compatibility](https://github.com/zigpy/zigpy-deconz) on top of ZiGate/TI/Silabs support in stable branch.
+* __stable6__: default branch provides stable support for these types of Zigbee Coordinator adapters/dongles/sticks/modules:
+  * [ZiGate](https://zigate.fr) models known today,
+  * [Electrolama zzh/zoe](https://electrolama.com/) models as well as [other Texas Instruments CC26x2/CC13x2 based adapters](https://github.com/zigpy/bellows/blob/dev/README.md#hardware-requirement) with newer [Z-Stack_3.x.0 firmware](https://github.com/Koenkk/Z-Stack-firmware/tree/master/coordinator/Z-Stack_3.x.0/bin),
+  * [Elelabs](https://elelabs.com/shop/)/[Popp](https://popp.eu/zb-stick/) models as well as [other Silicon Labs EFR32MG1x/EFR32MG2x based adapters](https://github.com/zigpy/zigpy-znp/blob/dev/README.md#hardware-requirements) with newer [EZSP v8 firmware](https://github.com/grobasoz/zigbee-firmware/).
 
 * Not supported
   * __stable5__: Support ALL ZiGate models known today and requires Domoticz 2020.x at minima (not supported anymore)


### PR DESCRIPTION
Update readme.md beta6 hardware compatibility.

Note that Popp's Zigbee Coordinator adapters are just a "[White Label](https://www.thatcompany.com/white-label-marketing/what-is-white-label)" versions of the same Elelabs Zigbee Coordinator adapters, so it's same hardware/firmware with Elelabs being [OEM (Original Equipment Manufacturer)](https://en.wikipedia.org/wiki/Original_equipment_manufacturer) / [ODM (Original Design Manufacturer)](https://en.wikipedia.org/wiki/Original_design_manufacturer). So the difference is only that the end-user need to go trhough Popp (now owned by Aeotec) for hardware warranty and support.

https://elelabs.com/products/elelabs-usb-adapter.html (ELU013) == https://popp.eu/zb-stick/ (POPE701554) == https://shop.zwave.eu/detail/index/sArticle/2496

https://elelabs.com/products/elelabs-zigbee-shield.html (ELR023) == https://popp.eu/zb-shield/ (POPE701561)== https://shop.zwave.eu/detail/index/sArticle/2497

Benefit for customers is that Popp branded Zigbee Coordinator adapters are usually easier to find locally in the European Union.