### PR TITLE
LIst of Associated Devices

### DIFF
--- a/Classes/ConfigureReporting.py
+++ b/Classes/ConfigureReporting.py
@@ -24,7 +24,8 @@ from Modules.zigateConsts import (MAX_LOAD_ZIGATE, ZIGATE_EP,
                                   CFG_RPT_ATTRIBUTESbyCLUSTERS)
 from Zigbee.zclCommands import (zcl_configure_reporting_requestv2,
                                 zcl_read_report_config_request)
-from Zigbee.zdpCommands import zdp_IEEE_address_request
+from Zigbee.zdpCommands import (zdp_IEEE_address_request,
+                                zdp_NWK_address_request)
 
 from Classes.ZigateTransport.sqnMgmt import (TYPE_APP_ZCL,
                                              sqn_get_internal_sqn_from_app_sqn)
@@ -524,8 +525,8 @@ def retreive_configuration_reporting_definition(self, NwkId):
 
 def do_rebind_if_needed(self, nwkid, Ep, batchMode, cluster):
     if batchMode and self.pluginconf.pluginConf["allowReBindingClusters"]:
-        zdp_IEEE_address_request(self, "0000", nwkid, )
-
+        lookup_ieee = self.ListOfDevices[nwkid]["IEEE"]
+        zdp_NWK_address_request(self, "fffc", lookup_ieee, )
         # Correctif 22 Novembre. Delete only for the specific cluster and not the all Set
         if (
             "Bind" in self.ListOfDevices[nwkid]

--- a/Classes/ConfigureReporting.py
+++ b/Classes/ConfigureReporting.py
@@ -13,27 +13,21 @@
 import time
 
 import Domoticz
-from Modules.basicOutputs import ieee_addr_request
 from Modules.bindings import bindDevice, unbindDevice
-from Modules.tools import (
-    get_isqn_datastruct,
-    get_list_isqn_attr_datastruct,
-    getClusterListforEP,
-    is_ack_tobe_disabled,
-    is_attr_unvalid_datastruct,
-    is_bind_ep,
-    is_fake_ep,
-    is_time_to_perform_work,
-    mainPoweredDevice,
-    reset_attr_datastruct,
-    set_isqn_datastruct,
-    set_status_datastruct,
-    set_timestamp_datastruct,
-)
-from Modules.zigateConsts import MAX_LOAD_ZIGATE, ZIGATE_EP, CFG_RPT_ATTRIBUTESbyCLUSTERS
-from Zigbee.zclCommands import zcl_configure_reporting_requestv2, zcl_read_report_config_request
+from Modules.tools import (get_isqn_datastruct, get_list_isqn_attr_datastruct,
+                           getClusterListforEP, is_ack_tobe_disabled,
+                           is_attr_unvalid_datastruct, is_bind_ep, is_fake_ep,
+                           is_time_to_perform_work, mainPoweredDevice,
+                           reset_attr_datastruct, set_isqn_datastruct,
+                           set_status_datastruct, set_timestamp_datastruct)
+from Modules.zigateConsts import (MAX_LOAD_ZIGATE, ZIGATE_EP,
+                                  CFG_RPT_ATTRIBUTESbyCLUSTERS)
+from Zigbee.zclCommands import (zcl_configure_reporting_requestv2,
+                                zcl_read_report_config_request)
+from Zigbee.zdpCommands import zdp_IEEE_address_request
 
-from Classes.ZigateTransport.sqnMgmt import TYPE_APP_ZCL, sqn_get_internal_sqn_from_app_sqn
+from Classes.ZigateTransport.sqnMgmt import (TYPE_APP_ZCL,
+                                             sqn_get_internal_sqn_from_app_sqn)
 
 MAX_ATTR_PER_REQ = 3
 CONFIGURE_REPORT_PERFORM_TIME = 21  # Reenforce will be done each xx hours
@@ -530,7 +524,8 @@ def retreive_configuration_reporting_definition(self, NwkId):
 
 def do_rebind_if_needed(self, nwkid, Ep, batchMode, cluster):
     if batchMode and self.pluginconf.pluginConf["allowReBindingClusters"]:
-        ieee_addr_request(self, nwkid)
+        zdp_IEEE_address_request(self, "0000", nwkid, )
+
         # Correctif 22 Novembre. Delete only for the specific cluster and not the all Set
         if (
             "Bind" in self.ListOfDevices[nwkid]

--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -1321,6 +1321,14 @@ SETTINGS = {
     "Experimental": {
         "Order": 15,
         "param": {
+            "broadcastNwkAddressRequest": {
+                "type": "int",
+                "default": 0,
+                "current": None,
+                "restart": 0,
+                "hidden": False,
+                "Advanced": True,
+            },
             "forceZigpy_noasyncio": {
                 "type": "bool",
                 "default": 0,
@@ -1328,7 +1336,6 @@ SETTINGS = {
                 "restart": 0,
                 "hidden": False,
                 "Advanced": True,
-  
             },
             "disableZCLDefaultResponse": {
                 "type": "bool",

--- a/Modules/basicOutputs.py
+++ b/Modules/basicOutputs.py
@@ -34,10 +34,10 @@ from Zigbee.zdpRawCommands import (zdp_management_binding_table_request,
 from Modules.sendZigateCommand import (raw_APS_request, send_zigatecmd_raw,
                                        send_zigatecmd_zcl_ack,
                                        send_zigatecmd_zcl_noack)
-from Modules.tools import (build_fcf, getListOfEpForCluster,
-                           is_ack_tobe_disabled, is_hex, mainPoweredDevice,
-                           set_isqn_datastruct, set_request_datastruct,
-                           set_timestamp_datastruct, get_and_inc_ZDP_SQN)
+from Modules.tools import (build_fcf, get_and_inc_ZDP_SQN,
+                           getListOfEpForCluster, is_ack_tobe_disabled, is_hex,
+                           mainPoweredDevice, set_isqn_datastruct,
+                           set_request_datastruct, set_timestamp_datastruct)
 from Modules.zigateCommands import (zigate_blueled,
                                     zigate_firmware_default_response,
                                     zigate_get_nwk_state, zigate_get_time,
@@ -688,13 +688,6 @@ def set_poweron_afteroffon(self, key, OnOffMode=0xFF):
         )
 
 
-def ieee_addr_request(self, lookup):
-    u8RequestType = "00"
-    u8StartIndex = "00"
-    zdp_IEEE_address_request(self, lookup, u8RequestType , u8StartIndex)
-    #sendZigateCmd(self, "0041", "02" + nwkid + u8RequestType + u8StartIndex)
-
-
 def unknown_device_nwkid(self, nwkid):
 
     if nwkid in self.UnknownDevices:
@@ -706,7 +699,7 @@ def unknown_device_nwkid(self, nwkid):
     # If we didn't find it, let's trigger a NetworkMap scan if not one in progress
     if self.networkmap and not self.networkmap.NetworkMapPhase():
         self.networkmap.start_scan()
-    ieee_addr_request(self, nwkid)
+    zdp_IEEE_address_request(self, "fffd", nwkid, )
 
 
 def send_default_response(

--- a/Modules/heartbeat.py
+++ b/Modules/heartbeat.py
@@ -366,7 +366,6 @@ def pingRetryDueToBadHealth(self, NwkId):
         self.ListOfDevices[NwkId]["pingDeviceRetry"]["TimeStamp"] = now
         lookup_ieee = self.ListOfDevices[ NwkId ]['IEEE']
         zdp_NWK_address_request(self, "fffc", lookup_ieee)
-        zdp_IEEE_address_request(self, "fffc", NwkId, )
         submitPing(self, NwkId)
         return
 
@@ -382,7 +381,6 @@ def pingRetryDueToBadHealth(self, NwkId):
         self.ListOfDevices[NwkId]["pingDeviceRetry"]["TimeStamp"] = now
         lookup_ieee = self.ListOfDevices[ NwkId ]['IEEE']
         zdp_NWK_address_request(self, "fffc", lookup_ieee)
-        zdp_IEEE_address_request(self, "fffc", NwkId, )
 
         submitPing(self, NwkId)
 

--- a/Modules/heartbeat.py
+++ b/Modules/heartbeat.py
@@ -667,17 +667,13 @@ def processKnownDevices(self, Devices, NWKID):
         _mainPowered 
         and "broadcastNwkAddressRequest" in self.pluginconf.pluginConf 
         and self.pluginconf.pluginConf["broadcastNwkAddressRequest"]
-        and not self.busy and self.ControllerLink.loadTransmit() < 3 
         and (intHB % ( self.pluginconf.pluginConf["broadcastNwkAddressRequest"] // HEARTBEAT) == 0)
     ):
-        lookup_ieee = self.ListOfDevices[ NWKID ]['IEEE']
-        zdp_NWK_address_request(self, "fffc", lookup_ieee, u8RequestType="01")
-        #zdp_IEEE_address_request(self, "fffc", NWKID, )
-
-
-    # Reenforcement of Legrand devices options if required
-    #if (self.HeartbeatCount % LEGRAND_FEATURES) == 0:
-    #    rescheduleAction = rescheduleAction or legrandReenforcement(self, NWKID)
+        if not self.busy and self.ControllerLink.loadTransmit() < 3:
+            lookup_ieee = self.ListOfDevices[ NWKID ]['IEEE']
+            zdp_NWK_address_request(self, "fffc", lookup_ieee, u8RequestType="01")
+        else:
+            rescheduleAction = True
 
     # Call Schneider Reenforcement if needed
     if self.pluginconf.pluginConf["reenforcementWiser"] and (self.HeartbeatCount % self.pluginconf.pluginConf["reenforcementWiser"]) == 0:

--- a/Modules/input.py
+++ b/Modules/input.py
@@ -215,7 +215,7 @@ def extract_messge_infos( Data):
     return MsgType, MsgData, MsgLQI
 
 def Decode0040(self, Devices, MsgData, MsgLQI):  # NWK_addr_req
-    self.log.logging("Input", "Log", "Decode0040 - NWK_addr_req: %s" % MsgData)
+    self.log.logging("Input", "Debug", "Decode0040 - NWK_addr_req: %s" % MsgData)
     
     # sqn + ieee + u8RequestType + u8StartIndex
     sqn = MsgData[:2]
@@ -225,10 +225,10 @@ def Decode0040(self, Devices, MsgData, MsgLQI):  # NWK_addr_req
     reqType = MsgData[24:26]
     startIndex = MsgData[26:28]
 
-    self.log.logging("Input", "Log", "      source req nwkid: %s" % srcNwkId)
-    self.log.logging("Input", "Log", "      request IEEE    : %s" % ieee)
-    self.log.logging("Input", "Log", "      request Type    : %s" % reqType)
-    self.log.logging("Input", "Log", "      request Idx     : %s" % startIndex)
+    self.log.logging("Input", "Debug", "      source req nwkid: %s" % srcNwkId)
+    self.log.logging("Input", "Debug", "      request IEEE    : %s" % ieee)
+    self.log.logging("Input", "Debug", "      request Type    : %s" % reqType)
+    self.log.logging("Input", "Debug", "      request Idx     : %s" % startIndex)
 
     # we should answer: sqn + status + ieee + nwkid + NumAssocDev + StartIndex + NWKAddrAssocDevList
     Cluster = "8000"
@@ -247,12 +247,12 @@ def Decode0040(self, Devices, MsgData, MsgLQI):  # NWK_addr_req
     else:
         status = "81"  # Device not found
         payload = sqn + status + ieee
-    self.log.logging("Input", "Log", "Decode0040 - response payload: %s" %payload)
+    self.log.logging("Input", "Debug", "Decode0040 - response payload: %s" %payload)
     raw_APS_request( self, srcNwkId, "00", Cluster, "0000", payload, zigpyzqn=sqn, zigate_ep="00", )
     
 
 def Decode0041(self, Devices, MsgData, MsgLQI):  # IEEE_addr_req
-    self.log.logging("Input", "Log", "Decode0041 - IEEE_addr_req: %s" % MsgData)
+    self.log.logging("Input", "Debug", "Decode0041 - IEEE_addr_req: %s" % MsgData)
 
     # sqn + nwkid + u8RequestType + u8StartIndex
     sqn = MsgData[:2]
@@ -262,10 +262,10 @@ def Decode0041(self, Devices, MsgData, MsgLQI):  # IEEE_addr_req
     reqType = MsgData[12:14]
     startIndex = MsgData[14:16]
 
-    self.log.logging("Input", "Log", "      source req nwkid: %s" % srcNwkId)
-    self.log.logging("Input", "Log", "      request NwkId    : %s" % nwkid)
-    self.log.logging("Input", "Log", "      request Type    : %s" % reqType)
-    self.log.logging("Input", "Log", "      request Idx     : %s" % startIndex)
+    self.log.logging("Input", "Debug", "      source req nwkid: %s" % srcNwkId)
+    self.log.logging("Input", "Debug", "      request NwkId    : %s" % nwkid)
+    self.log.logging("Input", "Debug", "      request Type    : %s" % reqType)
+    self.log.logging("Input", "Debug", "      request Idx     : %s" % startIndex)
 
     # we should answer: sqn + status + ieee + nwkid + NumAssocDev + StartIndex + NWKAddrAssocDevList
     Cluster = "8001"
@@ -284,7 +284,7 @@ def Decode0041(self, Devices, MsgData, MsgLQI):  # IEEE_addr_req
     else:
         status = "81"  # Device not found
         payload = sqn + status + nwkid
-    self.log.logging("Input", "Log", "Decode0041 - response payload: %s" %payload)
+    self.log.logging("Input", "Debug", "Decode0041 - response payload: %s" %payload)
     raw_APS_request( self, srcNwkId, "00", Cluster, "0000", payload, zigpyzqn=sqn, zigate_ep="00", )
 
 
@@ -476,7 +476,7 @@ def Decode0100(self, Devices, MsgData, MsgLQI):  # Read Attribute request
 
 def Decode0110(self, Devices, MsgData, MsgLQI):  # Write Attribute request
 
-    self.log.logging("Input", "Log", "Decode0110 - message: %s" % MsgData)
+    self.log.logging("Input", "Debug", "Decode0110 - message: %s" % MsgData)
     MsgSqn = MsgData[0:2]
     MsgSrcAddr = MsgData[2:6]
     MsgSrcEp = MsgData[6:8]
@@ -502,7 +502,7 @@ def Decode0110(self, Devices, MsgData, MsgLQI):  # Write Attribute request
 
         self.log.logging(
             "Input",
-            "Log",
+            "Debug",
             "Decode0110 - Sqn: %s NwkId: %s Ep: %s Cluster: %s Manuf: %s Attribute: %s Type: %s Value: %s"
             % (MsgSqn, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgManufCode, Attribute, DataType, DataValue),
         )
@@ -517,7 +517,7 @@ def Decode0302(self, Devices, MsgData, MsgLQI):  # PDM Load
 
 def Decode0400(self, Devices, MsgData, MsgLQI):  # Enrollment Request Response
 
-    self.log.logging("Input", "Log", "Decode0400 - message: %s" % MsgData)
+    self.log.logging("Input", "Debug", "Decode0400 - message: %s" % MsgData)
     # 02 0000 01 01 00 00
     # 02 0000 04 01 00 00
     # 02 426b 04 01 00 5c
@@ -988,7 +988,7 @@ def Decode8005(self, Devices, MsgData, MsgLQI):  # Command list
 
 def Decode8006(self, Devices, MsgData, MsgLQI):  # Non “Factory new” Restart
 
-    self.log.logging("Input", "Log", "Decode8006 - MsgData: %s" % (MsgData))
+    self.log.logging("Input", "Debug", "Decode8006 - MsgData: %s" % (MsgData))
 
     Status = MsgData[0:2]
     if Status == "00":
@@ -1022,7 +1022,7 @@ def Decode8007(self, Devices, MsgData, MsgLQI):  # “Factory new” Restart
 
 def Decode8008(self, Devices, MsgData, MsgLQI):  # ZiGate Heartbeat ( ZiGate V2 firmware 320)
 
-    self.log.logging("Input", "Log", "Decode8008: heartbeat:" + MsgData)
+    self.log.logging("Input", "Debug", "Decode8008: heartbeat:" + MsgData)
 
 
 def Decode8009(self, Devices, MsgData, MsgLQI):  # Network State response (Firm v3.0d)
@@ -1861,12 +1861,12 @@ def Decode8040(self, Devices, MsgData, MsgLQI):  # Network Address response
     # MsgLen = len(MsgData)
     # 0180020034ff000000800000000200000200000000bb57fe01008d15008a7d00ff03
     # 00/00/00158d0001fe57bb7d8a/00
-    self.log.logging( "Input", "Log", "Decode8040 - payload %s" %(MsgData))
+    self.log.logging( "Input", "Debug", "Decode8040 - payload %s" %(MsgData))
     MsgSequenceNumber = MsgData[:2]
     MsgDataStatus = MsgData[2:4]
     MsgIEEE = MsgData[4:20]
 
-    self.log.logging( "Input", "Log", "Decode8040 - Reception of Network Address response %s with status %s" %(MsgIEEE, MsgDataStatus))
+    self.log.logging( "Input", "Debug", "Decode8040 - Reception of Network Address response %s with status %s" %(MsgIEEE, MsgDataStatus))
 
     if MsgDataStatus != "00":
         return
@@ -1879,11 +1879,11 @@ def Decode8040(self, Devices, MsgData, MsgLQI):  # Network Address response
         MsgStartIndex = int( MsgData[26:28], 16)
         MsgDeviceList = MsgData[28:]
 
-    self.log.logging( "Input", "Log", "Network Address response, [%s] Status: %s Ieee: %s NwkId: %s" %(
+    self.log.logging( "Input", "Debug", "Network Address response, [%s] Status: %s Ieee: %s NwkId: %s" %(
         MsgSequenceNumber, DisplayStatusCode(MsgDataStatus), MsgIEEE, MsgShortAddress))
 
     if extendedResponse:
-        self.log.logging( "Input", "Log", "                        , Nb Associated Devices: %s Idx: %s Device List: %s" %(
+        self.log.logging( "Input", "Debug", "                        , Nb Associated Devices: %s Idx: %s Device List: %s" %(
             MsgNumAssocDevices, MsgStartIndex, MsgDeviceList))
 
     if extendedResponse and ( MsgStartIndex + len(MsgDeviceList) // 4) != MsgNumAssocDevices :
@@ -1916,7 +1916,7 @@ def Decode8040(self, Devices, MsgData, MsgLQI):  # Network Address response
             "Decode 8040 - Receive an IEEE: %s with a NwkId: %s, will try to reconnect" % (MsgIEEE, MsgShortAddress),
         )
         if not DeviceExist(self, Devices, MsgShortAddress, MsgIEEE):
-            self.log.logging("Input", "Log", "Decode 8040 - Not able to reconnect (unknown device)")
+            self.log.logging("Input", "Debug", "Decode 8040 - Not able to reconnect (unknown device)")
             return
 
     if extendedResponse:
@@ -1928,18 +1928,18 @@ def Decode8040(self, Devices, MsgData, MsgLQI):  # Network Address response
 
 def Network_Address_response_request_next_index(self, nwkid, ieee, index, ActualDevicesListed):
     new_index = "%02x" %( index + ActualDevicesListed )
-    self.log.logging("Input", "Log", "          Network_Address_response_request_next_index - %s Index: %s" %( nwkid, new_index))
+    self.log.logging("Input", "Debug", "          Network_Address_response_request_next_index - %s Index: %s" %( nwkid, new_index))
     zdp_NWK_address_request(self, nwkid, ieee, u8RequestType="01", u8StartIndex=new_index)
     
 def store_NwkAddr_Associated_Devices( self, nwkid, Index, device_associated_list):
-    self.log.logging("Input", "Log", "          store_NwkAddr_Associated_Devices - %s %s" %( nwkid, device_associated_list))
+    self.log.logging("Input", "Debug", "          store_NwkAddr_Associated_Devices - %s %s" %( nwkid, device_associated_list))
 
     if Index == 0:
         self.ListOfDevices[ nwkid ]["NWKAddrAssocDevList"] = []
     
     idx = 0
     while idx < len(device_associated_list):
-        device_id = device_associated_list[idx:idx+4]
+        device_id = device_associated_list[idx:idx + 4]
         if device_id not in self.ListOfDevices[ nwkid ]["NWKAddrAssocDevList"]:
             self.ListOfDevices[ nwkid ]["NWKAddrAssocDevList"].append( device_id )
         idx += 4
@@ -1960,14 +1960,14 @@ def Decode8041(self, Devices, MsgData, MsgLQI):  # IEEE Address response
     if MsgDataStatus != "00":
         self.log.logging(
             "Input",
-            "Log",
-            "Decode8041 - Reception of Node Descriptor for %s with status %s" %(MsgIEEE, MsgDataStatus))
+            "Debug",
+            "Decode8041 - Reception of IEEE Address response for %s with status %s" %(MsgIEEE, MsgDataStatus))
 
         return
 
     self.log.logging(
         "Input",
-        "Log",
+        "Debug",
         "Decode8041 - IEEE Address response, Sequence number: "
         + MsgSequenceNumber
         + " Status: "

--- a/Modules/input.py
+++ b/Modules/input.py
@@ -1935,13 +1935,13 @@ def store_NwkAddr_Associated_Devices( self, nwkid, Index, device_associated_list
     self.log.logging("Input", "Log", "          store_NwkAddr_Associated_Devices - %s %s" %( nwkid, device_associated_list))
 
     if Index == 0:
-        self.ListOfDevices[ nwkid ]["NwkAddr Device Associated"] = []
+        self.ListOfDevices[ nwkid ]["NWKAddrAssocDevList"] = []
     
     idx = 0
     while idx < len(device_associated_list):
         device_id = device_associated_list[idx:idx+4]
-        if device_id not in self.ListOfDevices[ nwkid ]["NwkAddr Device Associated"]:
-            self.ListOfDevices[ nwkid ]["NwkAddr Device Associated"].append( device_id )
+        if device_id not in self.ListOfDevices[ nwkid ]["NWKAddrAssocDevList"]:
+            self.ListOfDevices[ nwkid ]["NWKAddrAssocDevList"].append( device_id )
         idx += 4
 
       

--- a/Zigbee/zdpCommands.py
+++ b/Zigbee/zdpCommands.py
@@ -29,7 +29,7 @@ def zdp_NWK_address_request(self, router_nwkid, lookup_ieee, u8RequestType="00",
     # sourcery skip: replace-interpolation-with-fstring, use-fstring-for-concatenation
     # zdp_raw_NWK_address_request(self, router, ieee, u8RequestType, u8StartIndex)
     
-    self.log.logging("zdpCommand", "Log", "zdp_NWK_address_request %s %s %s" % (lookup_ieee, u8RequestType, u8StartIndex))
+    self.log.logging("zdpCommand", "Debug", "zdp_NWK_address_request %s %s %s" % (lookup_ieee, u8RequestType, u8StartIndex))
     if "ControllerInRawMode" in self.pluginconf.pluginConf and self.pluginconf.pluginConf["ControllerInRawMode"]:
         return zdp_raw_NWK_address_request(self, router_nwkid, lookup_ieee, u8RequestType, u8StartIndex)
     return send_zigatecmd_raw(self, "0040", "02" + router_nwkid + lookup_ieee + u8RequestType + u8StartIndex)
@@ -40,7 +40,7 @@ def zdp_IEEE_address_request(self, router_nwkid, lookup_nwkid, u8RequestType="00
     # zdp_raw_IEEE_address_request(self, router, nwkid, u8RequestType, u8StartIndex):
     # always send to node of interest rather than a cache
     
-    self.log.logging("zdpCommand", "Log", "zdp_IEEE_address_request %s %s %s" % (lookup_nwkid, u8RequestType, u8StartIndex))
+    self.log.logging("zdpCommand", "Debug", "zdp_IEEE_address_request %s %s %s" % (lookup_nwkid, u8RequestType, u8StartIndex))
     if "ControllerInRawMode" in self.pluginconf.pluginConf and self.pluginconf.pluginConf["ControllerInRawMode"]:
         return zdp_raw_IEEE_address_request(self, router_nwkid, lookup_nwkid, u8RequestType, u8StartIndex)
     return send_zigatecmd_raw(self, "0041", "02" + router_nwkid + lookup_nwkid + u8RequestType + u8StartIndex)

--- a/Zigbee/zdpCommands.py
+++ b/Zigbee/zdpCommands.py
@@ -14,6 +14,7 @@ from Modules.sendZigateCommand import raw_APS_request, send_zigatecmd_raw
 
 from Zigbee.zdpRawCommands import (zdp_raw_active_endpoint_request,
                                    zdp_raw_binding_device,
+                                   zdp_raw_IEEE_address_request,
                                    zdp_raw_leave_request,
                                    zdp_raw_node_descriptor_request,
                                    zdp_raw_NWK_address_request,
@@ -24,12 +25,25 @@ from Zigbee.zdpRawCommands import (zdp_raw_active_endpoint_request,
                                    zdp_raw_unbinding_device)
 
 
-def zdp_IEEE_address_request(self, lookup, u8RequestType, u8StartIndex):
-    self.log.logging("zdpCommand", "Debug", "zdp_IEEE_address_request %s %s %s" % (lookup, u8RequestType, u8StartIndex))
+def zdp_NWK_address_request(self, router_nwkid, lookup_ieee, u8RequestType="00", u8StartIndex="00"):
+    # sourcery skip: replace-interpolation-with-fstring, use-fstring-for-concatenation
+    # zdp_raw_NWK_address_request(self, router, ieee, u8RequestType, u8StartIndex)
+    
+    self.log.logging("zdpCommand", "Log", "zdp_NWK_address_request %s %s %s" % (lookup_ieee, u8RequestType, u8StartIndex))
     if "ControllerInRawMode" in self.pluginconf.pluginConf and self.pluginconf.pluginConf["ControllerInRawMode"]:
-        return zdp_raw_NWK_address_request(self, "0000", lookup, u8RequestType, u8StartIndex)
-    return send_zigatecmd_raw(self, "0041", "02" + lookup + lookup + u8RequestType + u8StartIndex)
+        return zdp_raw_NWK_address_request(self, router_nwkid, lookup_ieee, u8RequestType, u8StartIndex)
+    return send_zigatecmd_raw(self, "0040", "02" + router_nwkid + lookup_ieee + u8RequestType + u8StartIndex)
 
+
+def zdp_IEEE_address_request(self, router_nwkid, lookup_nwkid, u8RequestType="00", u8StartIndex="00"):
+    # sourcery skip: replace-interpolation-with-fstring, use-fstring-for-concatenation
+    # zdp_raw_IEEE_address_request(self, router, nwkid, u8RequestType, u8StartIndex):
+    # always send to node of interest rather than a cache
+    
+    self.log.logging("zdpCommand", "Log", "zdp_IEEE_address_request %s %s %s" % (lookup_nwkid, u8RequestType, u8StartIndex))
+    if "ControllerInRawMode" in self.pluginconf.pluginConf and self.pluginconf.pluginConf["ControllerInRawMode"]:
+        return zdp_raw_IEEE_address_request(self, router_nwkid, lookup_nwkid, u8RequestType, u8StartIndex)
+    return send_zigatecmd_raw(self, "0041", "02" + router_nwkid + lookup_nwkid + u8RequestType + u8StartIndex)
 
 def zdp_node_descriptor_request(self, nwkid):
     self.log.logging("zdpCommand", "Debug", "zdp_node_descriptor_request %s" % (nwkid,))

--- a/Zigbee/zdpDecoders.py
+++ b/Zigbee/zdpDecoders.py
@@ -276,7 +276,7 @@ def buildframe_nwk_address_response(self, SrcNwkId, SrcEndPoint, ClusterId, Payl
     else:
         nwkid = "%04x" % struct.unpack("H", struct.pack(">H", int(Payload[20:24], 16)))[0]
 
-        self.log.logging("zdpDecoder", "Log", "buildframe_nwk_address_response sqn: %s status: %s ieee: %s nwkid: %s" %( sqn, status, ieee, nwkid))
+        self.log.logging("zdpDecoder", "Debug", "buildframe_nwk_address_response sqn: %s status: %s ieee: %s nwkid: %s" %( sqn, status, ieee, nwkid))
         NumAssocDev = Payload[24:26] if len(Payload) > 24 else ""
         StartIndex = Payload[26:28] if len(Payload) > 26 else ""
         if len(Payload) > 28:

--- a/Zigbee/zdpDecoders.py
+++ b/Zigbee/zdpDecoders.py
@@ -272,12 +272,11 @@ def buildframe_nwk_address_response(self, SrcNwkId, SrcEndPoint, ClusterId, Payl
     status = Payload[2:4]
     ieee = "%016x" % struct.unpack("Q", struct.pack(">Q", int(Payload[4:20], 16)))[0]
     if status != "00":
-        
         buildPayload = sqn + status + ieee
     else:
         nwkid = "%04x" % struct.unpack("H", struct.pack(">H", int(Payload[20:24], 16)))[0]
-    
-        self.log.logging("zdpDecoder", "Debug", "buildframe_nwk_address_response sqn: %s status: %s ieee: %s nwkid: %s" %( sqn, status, ieee, nwkid))
+
+        self.log.logging("zdpDecoder", "Log", "buildframe_nwk_address_response sqn: %s status: %s ieee: %s nwkid: %s" %( sqn, status, ieee, nwkid))
         NumAssocDev = Payload[24:26] if len(Payload) > 24 else ""
         StartIndex = Payload[26:28] if len(Payload) > 26 else ""
         if len(Payload) > 28:

--- a/Zigbee/zdpRawCommands.py
+++ b/Zigbee/zdpRawCommands.py
@@ -18,6 +18,7 @@ from Modules.tools import get_and_inc_ZDP_SQN
 
 
 def zdp_raw_NWK_address_request(self, router, ieee, u8RequestType, u8StartIndex):
+    # sourcery skip: replace-interpolation-with-fstring, use-fstring-for-concatenation
 
     Cluster = "0000"
     sqn = get_and_inc_ZDP_SQN(self, router)
@@ -45,7 +46,9 @@ def zdp_raw_NWK_address_request(self, router, ieee, u8RequestType, u8StartIndex)
     return sqn
 
 
-def zdp_raw_IEEE_address_request(self, nwkid, u8RequestType, u8StartIndex):
+def zdp_raw_IEEE_address_request(self, router, nwkid, u8RequestType, u8StartIndex):
+    # sourcery skip: replace-interpolation-with-fstring, use-fstring-for-concatenation
+    
     Cluster = "0001"
     sqn = get_and_inc_ZDP_SQN(self, nwkid)
     payload = sqn + "%04x" % struct.unpack(">H", struct.pack("H", int(nwkid, 16)))[0] + u8RequestType + u8StartIndex
@@ -59,7 +62,7 @@ def zdp_raw_IEEE_address_request(self, nwkid, u8RequestType, u8StartIndex):
 
     raw_APS_request(
         self,
-        nwkid,
+        router,
         "00",
         Cluster,
         "0000",

--- a/plugin.py
+++ b/plugin.py
@@ -69,12 +69,11 @@
 </plugin>
 """
 
-import sys
 import pathlib
-
-from pkg_resources import DistributionNotFound
+import sys
 
 import Domoticz
+from pkg_resources import DistributionNotFound
 
 try:
     from Domoticz import Devices, Images, Parameters, Settings
@@ -83,10 +82,10 @@ except ImportError:
 
 import gc
 import json
+import os
 import sys
 import threading
 import time
-import os
 
 from Classes.AdminWidgets import AdminWidgets
 # from Classes.APS import APSManagement
@@ -103,8 +102,7 @@ from Classes.PluginConf import PluginConf
 from Classes.TransportStats import TransportStatistics
 from Classes.WebServer.WebServer import WebServer
 from Modules.basicOutputs import (ZigatePermitToJoin,
-                                  do_Many_To_One_RouteRequest,
-                                  ieee_addr_request, leaveRequest,
+                                  do_Many_To_One_RouteRequest, leaveRequest,
                                   setExtendedPANID, setTimeServer,
                                   start_Zigate, zigateBlueLed)
 from Modules.casaia import restart_plugin_reset_ModuleIRCode


### PR DESCRIPTION
* Create a list of associated devices. List of end devices attached to a router
* use the NWK_Addr_req when getting ping error 
* do a NWK_Addr_req prior to a bind/unbind (in the Configure Reporting).
* broadcastNwkAddressRequest setting to enable the List construction. the parameters correspond to the number of seconds to re-interate the request per device
* when receiving a message from unknown devices ( ShortId not found), then do a IEEE_Addr_req