### PR TITLE
Merge upstream bellows 0.43.3

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1494,7 +1494,7 @@ def check_python_modules_version( self ):
         "zigpy_znp": "0.9.1",
         "zigpy_deconz": "0.19.1",
         "zigpy_zigate": "0.8.1.zigbeefordomoticz",
-        "zigpy_ezsp": "0.34.2",
+        "zigpy_ezsp": "0.34.3",
         }
 
     flag = True


### PR DESCRIPTION
- Allow disabling the bellows UART thread
- Allow configuration options to be disabled
- make ACK dependents on packet.tx_options