### PR TITLE
Enable by default storage of Plugin Db into Domoticz 

### DIFF
--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -205,6 +205,7 @@ SETTINGS = {
             "pluginReports": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
             "pluginWWW": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
             "pluginLogs": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
+            "storeDomoticzDatabase": {"type": "bool","default": 1,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
         },
     },
     # Verbose
@@ -311,7 +312,6 @@ SETTINGS = {
         "Order": 16,
         "param": {
             "TryFindingIeeeOfUnknownNwkid": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
-            "storeDomoticzDatabase": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
             "useDomoticzDatabase": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
         },
     },


### PR DESCRIPTION
This feature is there since a while now. And running pretty well on my systems.

So it will enable to write the plugin Db into DeviceList-xx.txt **and** in the Sqlite3 Domoticz Db.

At startup only the DevivceList-xx.txt is used for now