### PR TITLE
For EZSP chipset, the IEEE can be updated/overwriten only once,

### DIFF
--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -63,6 +63,7 @@ SETTINGS = {
             "Terncy": {"type": "bool", "default": 0, "current": None, "restart": 1, "hidden": False, "Advanced": True,},
             "Wiser": {"type": "bool", "default": 0, "current": None, "restart": 1, "hidden": False, "Advanced": True, },
             "Wiser2": {"type": "bool", "default": 0, "current": None, "restart": 1, "hidden": False, "Advanced": True,},
+            "OverWriteCoordinatorIEEEOnlyOnce": {"type": "bool", "default": 0, "current": None, "restart": 1, "hidden": False, "Advanced": True, "ZigpyRadio": "ezsp"},
             "autoBackup": { "type": "bool", "default": 1, "current": None, "restart": 0, "hidden": False, "Advanced": False, },
             "autoRestore": {"type": "bool", "default": 1, "current": None, "restart": 0, "hidden": False, "Advanced": True,},
     

--- a/Classes/ZigpyTransport/AppGeneric.py
+++ b/Classes/ZigpyTransport/AppGeneric.py
@@ -41,9 +41,14 @@ async def initialize(self, *, auto_form: bool = False, force_form: bool = False)
         _retreived_backup = do_retreive_backup( self )
         if _retreived_backup:
             _retreived_backup = NetworkBackup.from_dict( _retreived_backup )
+
         if _retreived_backup:
+            if self.pluginconf.pluginConf[ "OverWriteCoordinatorIEEEOnlyOnce"]:
+                LOGGER.debug("Allow eui64 overwrite only once !!!") 
+                _retreived_backup.network_info.stack_specific.setdefault("ezsp", {})[ "i_understand_i_can_update_eui64_only_once_and_i_still_want_to_do_it"] = True
+
             LOGGER.debug("Last backup retreived: %s" % _retreived_backup )
-            self.backups.add_backup( backup= _retreived_backup )
+            self.backups.add_backup( backup=_retreived_backup )
 
     if force_form:
         with contextlib.suppress(Exception):


### PR DESCRIPTION
In case you restore a backup from an other Zigbee , you have one chance to do it. 

A parameter has been added to support such action. If  OverWriteCoordinatorIEEEOnlyOnce is set to True, then the plugin when restoring the previous backup will enable the possibility to overwrite the eu64.

However it the the responsibility of the user to know that the eui64 has never been updating

eui64 is the Mac-Address/IEEE of the coordinator