### PR TITLE
Fixes to Danfoss external temperature sensor

### DIFF
--- a/Modules/danfoss.py
+++ b/Modules/danfoss.py
@@ -78,6 +78,10 @@ def danfoss_write_external_sensor_temp(self, NwkId, external_temperature):
     self.log.logging("Danfoss", "Debug", "danfoss_write_external_sensor_temp: %s %s" % (
         NwkId, external_temperature), nwkid=NwkId)
 
+    if isinstance(external_temperature, float):
+        self.log.logging("Danfoss", "Debug", "danfoss_write_external_sensor_temp float to int")
+        external_temperature = int (external_temperature*100)
+
     external_temperature = int( (50 * external_temperature) // 50)
 
     manuf_id = "1246"
@@ -149,6 +153,9 @@ def danfoss_room_sensor_polling(self, NwkId):
         if "Param" not in self.ListOfDevices[x]:
             continue
         if "DanfossRoom" not in self.ListOfDevices[x]["Param"]:
+            continue
+        if "DanfossFreq" in self.ListOfDevices[x]["Param"]:
+            self.log.logging( "Danfoss", "Debug", "danfoss_room_sensor_polling rejecting thermostat for ext temp")
             continue
         if self.ListOfDevices[x]["Param"]["DanfossRoom"] != room:
             continue

--- a/Modules/danfoss.py
+++ b/Modules/danfoss.py
@@ -154,10 +154,10 @@ def danfoss_room_sensor_polling(self, NwkId):
             continue
         if "DanfossRoom" not in self.ListOfDevices[x]["Param"]:
             continue
-        if "DanfossFreq" in self.ListOfDevices[x]["Param"]:
-            self.log.logging( "Danfoss", "Debug", "danfoss_room_sensor_polling rejecting thermostat for ext temp")
-            continue
         if self.ListOfDevices[x]["Param"]["DanfossRoom"] != room:
+            continue
+        if "DanfossRoomFreq" in self.ListOfDevices[x]["Param"]:
+            self.log.logging( "Danfoss", "Debug", "danfoss_room_sensor_polling rejecting thermostat for ext temp")
             continue
 
         ep_list = getListOfEpForCluster(self, x, "0402")


### PR DESCRIPTION
Detect whether temperatures are floting number or int and convert to int (100 * celcius)
Check for DanfossRoomFreq parameter in temperature sensor device and dont use if found.
Enables using one external sensor for several thermostats