### PR TITLE
Refactor/usering pathlib path

### DIFF
--- a/Classes/LoggingManagement.py
+++ b/Classes/LoggingManagement.py
@@ -24,7 +24,7 @@ from queue import PriorityQueue, Queue
 import Domoticz
 
 LOG_ERROR_HISTORY = "PluginZigbee_log_error_history.json"
-LOG_FILE = "/PluginZigbee_"
+LOG_FILE = "PluginZigbee_"
 
 class LoggingManagement:
     def __init__(self, pluginconf, PluginHealth, HardwareID, ListOfDevices, permitTojoin):
@@ -147,30 +147,32 @@ class LoggingManagement:
         if not self.pluginconf.pluginConf["enablePluginLogging"]:
             return
 
-        logfilename = self.pluginconf.pluginConf["pluginLogs"] + LOG_FILE + "%02d" % self.HardwareID + ".log"
+        _pluginlogs =  Path( self.pluginconf.pluginConf["pluginLogs"] )
+        _logfilename = _pluginlogs / ( LOG_FILE + "%02d.log" % self.HardwareID) 
+        
         _backupCount = 7  # Keep 7 days of Logging
         _maxBytes = 0
         if "loggingBackupCount" in self.pluginconf.pluginConf:
             _backupCount = int(self.pluginconf.pluginConf["loggingBackupCount"])
         if "loggingMaxMegaBytes" in self.pluginconf.pluginConf:
             _maxBytes = int(self.pluginconf.pluginConf["loggingMaxMegaBytes"]) * 1024 * 1024
-        Domoticz.Status("Please watch plugin log into %s" % logfilename)
+        Domoticz.Status("Please watch plugin log into %s" % _logfilename)
         if _maxBytes == 0:
             # Enable TimedRotating
             logging.basicConfig(
                 level=logging.DEBUG,
                 format="%(asctime)s %(levelname)-8s:%(message)s",
-                handlers=[TimedRotatingFileHandler(logfilename, when="midnight", interval=1, backupCount=_backupCount)],
+                handlers=[TimedRotatingFileHandler(_logfilename, when="midnight", interval=1, backupCount=_backupCount)],
             )
         else:
             # Enable RotatingFileHandler
             logging.basicConfig(
                 level=logging.DEBUG,
                 format="%(asctime)s %(levelname)-8s:%(message)s",
-                handlers=[RotatingFileHandler(logfilename, maxBytes=_maxBytes, backupCount=_backupCount)],
+                handlers=[RotatingFileHandler(_logfilename, maxBytes=_maxBytes, backupCount=_backupCount)],
             )
         if "PluginLogMode" in self.pluginconf.pluginConf and self.pluginconf.pluginConf["PluginLogMode"] in ( 0o640, 0o640, 0o644 ):
-                os.chmod(logfilename, self.pluginconf.pluginConf["PluginLogMode"])
+                os.chmod(_logfilename, self.pluginconf.pluginConf["PluginLogMode"])
 
 
 

--- a/Classes/LoggingManagement.py
+++ b/Classes/LoggingManagement.py
@@ -147,7 +147,7 @@ class LoggingManagement:
         if not self.pluginconf.pluginConf["enablePluginLogging"]:
             return
 
-        _pluginlogs =  Path( self.pluginconf.pluginConf["pluginLogs"] )
+        _pluginlogs = Path(self.pluginconf.pluginConf["pluginLogs"] )
         _logfilename = _pluginlogs / ( LOG_FILE + "%02d.log" % self.HardwareID) 
         
         _backupCount = 7  # Keep 7 days of Logging

--- a/Classes/LoggingManagement.py
+++ b/Classes/LoggingManagement.py
@@ -14,6 +14,8 @@
 import json
 import logging
 import os
+import os.path
+from pathlib import Path
 import threading
 import time
 from logging.handlers import RotatingFileHandler, TimedRotatingFileHandler
@@ -173,7 +175,8 @@ class LoggingManagement:
 
 
     def open_log_history(self):
-        jsonLogHistory = self.pluginconf.pluginConf["pluginLogs"] + "/" + LOG_ERROR_HISTORY
+        _pluginlogs = Path( self.pluginconf.pluginConf["pluginLogs"] )
+        jsonLogHistory = _pluginlogs / LOG_ERROR_HISTORY
         try:
             handle = open(jsonLogHistory, "r", encoding="utf-8")
         except Exception as e:
@@ -406,7 +409,8 @@ def loggingBuildContext(self, thread_name, module, message, nwkid, context):
 
 
 def loggingWriteErrorHistory(self):
-    jsonLogHistory = self.pluginconf.pluginConf["pluginLogs"] + "/" + LOG_ERROR_HISTORY
+    _pluginlogs = Path( self.pluginconf.pluginConf["pluginLogs"] )
+    jsonLogHistory =_pluginlogs / LOG_ERROR_HISTORY
     with open(jsonLogHistory, "w", encoding="utf-8") as json_file:
         try:
             json.dump(dict(self.LogErrorHistory), json_file)

--- a/Classes/NetworkEnergy.py
+++ b/Classes/NetworkEnergy.py
@@ -23,6 +23,7 @@
 
 import json
 import os.path
+from pathlib import Path
 from time import time
 
 import Domoticz
@@ -300,10 +301,8 @@ class NetworkEnergy:
 
         self.logging("Debug", "Network Energly Level Report: %s" % storeEnergy)
 
-        _filename = (
-            self.pluginconf.pluginConf["pluginReports"] + "NetworkEnergy-v3-" + "%02d" % self.HardwareID + ".json"
-        )
-        if os.path.isdir(self.pluginconf.pluginConf["pluginReports"]):
+        _filename = Path( self.pluginconf.pluginConf["pluginReports"] ) / ("NetworkEnergy-v3-" + "%02d.json" % self.HardwareID)
+        if os.path.isdir( Path(self.pluginconf.pluginConf["pluginReports"]) ):
 
             nbentries = 0
             if os.path.isfile(_filename):

--- a/Classes/NetworkMap.py
+++ b/Classes/NetworkMap.py
@@ -26,6 +26,7 @@
 
 import json
 import os.path
+from pathlib import Path
 import time
 from datetime import datetime
 
@@ -270,9 +271,8 @@ def finish_scan(self):
     del self.ListOfDevices["0000"]["TopologyStartTime"]
     
 def save_report_to_file(self, storeLQI):
-    _filename = self.pluginconf.pluginConf["pluginReports"] + "NetworkTopology-v3-" + "%02d" % self.HardwareID + ".json"
-    if os.path.isdir(self.pluginconf.pluginConf["pluginReports"]):
-
+    _filename = Path( self.pluginconf.pluginConf["pluginReports"] ) / ("NetworkTopology-v3-" + "%02d.json" % self.HardwareID)
+    if os.path.isdir( Path(self.pluginconf.pluginConf["pluginReports"]) ):
         nbentries = 0
         if os.path.isfile(_filename):
             with open(_filename, "r") as fin:

--- a/Classes/OTA.py
+++ b/Classes/OTA.py
@@ -33,6 +33,7 @@ import time
 from datetime import datetime
 from os import listdir
 from os.path import isfile, join, exists
+from pathlib import Path
 
 import Domoticz
 from Modules.sendZigateCommand import sendZigateCmd
@@ -914,7 +915,7 @@ def check_image_valid_version(self, brand, image_type, ota_image_file, headers):
 
 def ota_extract_image_headers(self, subfolder, image):  # OK 13/10
     # Load headers from the image
-    ota_image = _open_image_file(self, self.pluginconf.pluginConf["pluginOTAFirmware"] + subfolder + "/" + image)
+    ota_image = _open_image_file(self, Path( self.pluginconf.pluginConf["pluginOTAFirmware"]) / subfolder / image)
     if ota_image is None:
         logging( self, "Error", "ota_extract_image_headers - unable to open file %s" % (self.pluginconf.pluginConf["pluginOTAFirmware"] + subfolder + "/" + image), )
         return None

--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -321,6 +321,7 @@ SETTINGS = {
     "Experimental": {
         "Order": 16,
         "param": {
+            "PosixPathUpdate": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
             "readZclClusters": {"type": "bool","default": 1,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
             "reconnectonIEEEaddr": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
             "reconnectonNWKaddr": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
@@ -424,7 +425,7 @@ class PluginConf:
         setup_folder_parameters(self, homedir)
 
         #self.pluginConf["filename"] = self.pluginConf["pluginConfig"] + "PluginConf-%02d.json" % hardwareid
-        _pluginConf = Path ( self.pluginConf["pluginConfig"] )
+        _pluginConf = Path(self.pluginConf["pluginConfig"] )
         self.pluginConf["filename"] = str( _pluginConf / ("PluginConf-%02d.json" % hardwareid) )
         if os.path.isfile( _pluginConf / ("PluginConf-%02d.json" % hardwareid)):
             _load_Settings(self)
@@ -452,7 +453,7 @@ class PluginConf:
         # Only the arameters which are different than default '
 
         #self.pluginConf["filename"] = self.pluginConf["pluginConfig"] + "PluginConf-%02d.json" % self.hardwareid
-        _pluginConf = Path ( self.pluginConf["pluginConfig"] )
+        _pluginConf = Path(self.pluginConf["pluginConfig"] )
         pluginConfFile = _pluginConf / ("PluginConf-%02d.json" % self.hardwareid)
         self.pluginConf["filename"] = str(pluginConfFile)
     
@@ -466,9 +467,6 @@ class PluginConf:
                         write_pluginConf[param] = self.pluginConf[param]
 
         with open(pluginConfFile, "wt") as handle:
-            
-            for x in write_pluginConf:
-                Domoticz.Error( "%s %s %s" %( x , write_pluginConf[x], type( write_pluginConf[x])))
             json.dump(write_pluginConf, handle, sort_keys=True, indent=2)
 
             
@@ -598,8 +596,17 @@ def _path_check(self):
             if self.pluginConf[param].find("http") != -1:
                 # this is a url
                 continue
-            if not os.path.exists(self.pluginConf[param]):
-                Domoticz.Error("Cannot access path: %s" % self.pluginConf[param])
+            _path_name = Path( self.pluginConf[param] )
+
+            if not os.path.exists(_path_name):
+                Domoticz.Error("Cannot access path: %s" % _path_name)
+
+            if self.pluginConf[param] != str( _path_name ):
+                if self.pluginConf["PosixPathUpdate"]:
+                    Domoticz.Status("Updating path from %s to %s" %( self.pluginConf[param], _path_name))
+                    self.pluginConf[param] = str( _path_name )
+                else:
+                    Domoticz.Error("Updating path from %s to %s is required, but no backward compatibility" %( self.pluginConf[param], _path_name))
 
 
 def _param_checking(self):

--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -415,7 +415,7 @@ class PluginConf:
         self.pluginConf = {}
         self.homedir = homedir
         self.hardwareid = hardwareid
-        self.pluginConf["pluginHome"] = homedir
+        self.pluginConf["pluginHome"] = homedir.rstrip('/').rstrip('\\')
         self.VersionNewFashion = VersionNewFashion
         self.DomoticzMajor = DomoticzMajor
         self.DomoticzMinor = DomoticzMinor

--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -448,6 +448,7 @@ class PluginConf:
         _path_check(self)
         _param_checking(self)
 
+
     def write_Settings(self):
         # serialize json format the pluginConf '
         # Only the arameters which are different than default '
@@ -588,7 +589,7 @@ def _import_oldfashon_param(self, tmpPluginConf, filename):
 
 
 def _path_check(self):
-
+    update_done = False
     for theme in SETTINGS:
         for param in SETTINGS[theme]["param"]:
             if SETTINGS[theme]["param"][param]["type"] != "path":
@@ -597,17 +598,18 @@ def _path_check(self):
                 # this is a url
                 continue
             _path_name = Path( self.pluginConf[param] )
-
             if not os.path.exists(_path_name):
                 Domoticz.Error("Cannot access path: %s" % _path_name)
-
             if self.pluginConf[param] != str( _path_name ):
                 if self.pluginConf["PosixPathUpdate"]:
                     Domoticz.Status("Updating path from %s to %s" %( self.pluginConf[param], _path_name))
                     self.pluginConf[param] = str( _path_name )
+                    update_done = True
                 else:
                     Domoticz.Error("Updating path from %s to %s is required, but no backward compatibility" %( self.pluginConf[param], _path_name))
 
+    if update_done:
+        self.write_Settings()
 
 def _param_checking(self):
     # Let's check the Type

--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -13,6 +13,7 @@ Parameters not define in the PluginConf.txt file will be set to their default va
 
 import json
 import os.path
+from pathlib import Path
 import time
 
 import Domoticz
@@ -422,8 +423,10 @@ class PluginConf:
 
         setup_folder_parameters(self, homedir)
 
-        self.pluginConf["filename"] = self.pluginConf["pluginConfig"] + "PluginConf-%02d.json" % hardwareid
-        if os.path.isfile(self.pluginConf["filename"]):
+        #self.pluginConf["filename"] = self.pluginConf["pluginConfig"] + "PluginConf-%02d.json" % hardwareid
+        _pluginConf = Path ( self.pluginConf["pluginConfig"] )
+        self.pluginConf["filename"] = str( _pluginConf / ("PluginConf-%02d.json" % hardwareid) )
+        if os.path.isfile( _pluginConf / ("PluginConf-%02d.json" % hardwareid)):
             _load_Settings(self)
 
         else:
@@ -448,8 +451,11 @@ class PluginConf:
         # serialize json format the pluginConf '
         # Only the arameters which are different than default '
 
-        self.pluginConf["filename"] = self.pluginConf["pluginConfig"] + "PluginConf-%02d.json" % self.hardwareid
-        pluginConfFile = self.pluginConf["filename"]
+        #self.pluginConf["filename"] = self.pluginConf["pluginConfig"] + "PluginConf-%02d.json" % self.hardwareid
+        _pluginConf = Path ( self.pluginConf["pluginConfig"] )
+        pluginConfFile = _pluginConf / ("PluginConf-%02d.json" % self.hardwareid)
+        self.pluginConf["filename"] = str(pluginConfFile)
+    
         write_pluginConf = {}
         for theme in SETTINGS:
             for param in SETTINGS[theme]["param"]:
@@ -460,7 +466,12 @@ class PluginConf:
                         write_pluginConf[param] = self.pluginConf[param]
 
         with open(pluginConfFile, "wt") as handle:
+            
+            for x in write_pluginConf:
+                Domoticz.Error( "%s %s %s" %( x , write_pluginConf[x], type( write_pluginConf[x])))
             json.dump(write_pluginConf, handle, sort_keys=True, indent=2)
+
+            
 
         if is_domoticz_db_available(self) and (self.pluginConf["useDomoticzDatabase"] or self.pluginConf["storeDomoticzDatabase"]):
             setConfigItem(Key="PluginConf", Value={"TimeStamp": time.time(), "b64Settings": write_pluginConf})
@@ -522,21 +533,22 @@ def _load_Settings(self):
 def _load_oldfashon(self, homedir, hardwareid):
     # Import PluginConf.txt
     # Migration
-    self.pluginConf["filename"] = self.pluginConf["pluginConfig"] + "PluginConf-%02d.txt" % hardwareid
-    if not os.path.isfile(self.pluginConf["filename"]):
-        self.pluginConf["filename"] = self.pluginConf["pluginConfig"] + "PluginConf-%d.txt" % hardwareid
-        if not os.path.isfile(self.pluginConf["filename"]):
-            self.pluginConf["filename"] = self.pluginConf["pluginConfig"] + "PluginConf.txt"
-            if not os.path.isfile(self.pluginConf["filename"]):
+    _filename = Path(self.pluginConf["pluginConfig"]) / ("PluginConf-%02d.txt" % hardwareid)
+    if not os.path.isfile(_filename):
+        _filename = Path(self.pluginConf["pluginConfig"]) / ("PluginConf-%2d.txt" % hardwareid)
+        if not os.path.isfile(_filename):
+            _filename = Path(self.pluginConf["pluginConfig"]) / "PluginConf.txt"
+            if not os.path.isfile(_filename):
                 self.write_Settings()
+                self.pluginConf["filename"] = str( _filename )
                 return
 
     tmpPluginConf = ""
-    if not os.path.isfile(self.pluginConf["filename"]):
+    if not os.path.isfile(_filename):
         return
-    with open(self.pluginConf["filename"], "r") as myPluginConfFile:
+    with open(_filename, "r") as myPluginConfFile:
         tmpPluginConf += myPluginConfFile.read().replace("\n", "")
-
+    self.pluginConf["filename"] = str( _filename )
     PluginConf = {}
     _import_oldfashon_param(self, tmpPluginConf, self.pluginConf["filename"])
 
@@ -619,23 +631,24 @@ def zigpy_setup(self):
                 }
                                 
 def setup_folder_parameters(self, homedir):
+
     for theme in SETTINGS:
         for param in SETTINGS[theme]["param"]:
             if param == "pluginHome":
                 continue
             if param == "homedirectory":
-                self.pluginConf[param] = homedir
+                self.pluginConf[param] = str( Path(homedir) )
             elif param == "pluginConfig":
-                self.pluginConf[param] = self.pluginConf["pluginHome"] + "Conf/"
+                self.pluginConf[param] = str( Path(self.pluginConf["pluginHome"]) / "Conf")
             elif param == "pluginData":
-                self.pluginConf[param] = self.pluginConf["pluginHome"] + "Data/"
+                self.pluginConf[param] = str( Path(self.pluginConf["pluginHome"]) / "Data")
             elif param == "pluginLogs":
-                self.pluginConf[param] = self.pluginConf["pluginHome"] + "Logs/"
+                self.pluginConf[param] = str( Path(self.pluginConf["pluginHome"]) / "Logs")
             elif param == "pluginOTAFirmware":
-                self.pluginConf[param] = self.pluginConf["pluginHome"] + "OTAFirmware/"
+                self.pluginConf[param] = str( Path(self.pluginConf["pluginHome"]) / "OTAFirmware")
             elif param == "pluginReports":
-                self.pluginConf[param] = self.pluginConf["pluginHome"] + "Reports/"
+                self.pluginConf[param] = str( Path(self.pluginConf["pluginHome"]) / "Reports")
             elif param == "pluginWWW":
-                self.pluginConf[param] = self.pluginConf["pluginHome"] + "www/"
+                self.pluginConf[param] = str( Path(self.pluginConf["pluginHome"]) / "www")
             else:
                 self.pluginConf[param] = SETTINGS[theme]["param"][param]["default"]

--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -198,6 +198,8 @@ SETTINGS = {
     "PluginConfiguration": {
         "Order": 12,
         "param": {
+            "PosixPathUpdate": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
+            "storeDomoticzDatabase": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
             "PluginLogMode": {"type": "list","list": { "system default": 0, "0600": 0o600, "0640": 0o640, "0644": 0o644},"default": 0,"current": None,"restart": 1,"hidden": False,"Advanced": True,},
             "numDeviceListVersion": {"type": "int","default": 12,"current": None,"restart": 0,"hidden": False,"Advanced": False,},
             "filename": { "type": "path", "default": "", "current": None, "restart": 1, "hidden": True, "Advanced": True, },
@@ -209,7 +211,6 @@ SETTINGS = {
             "pluginReports": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
             "pluginWWW": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
             "pluginLogs": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
-            "storeDomoticzDatabase": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
         },
     },
     # Verbose
@@ -321,7 +322,7 @@ SETTINGS = {
     "Experimental": {
         "Order": 16,
         "param": {
-            "PosixPathUpdate": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
+            
             "readZclClusters": {"type": "bool","default": 1,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
             "reconnectonIEEEaddr": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},
             "reconnectonNWKaddr": {"type": "bool","default": 0,"current": None,"restart": 0,"hidden": False,"Advanced": True,},

--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -463,7 +463,10 @@ class PluginConf:
             for param in SETTINGS[theme]["param"]:
                 if self.pluginConf[param] != SETTINGS[theme]["param"][param]["default"]:
                     if SETTINGS[theme]["param"][param]["type"] == "hex":
-                        write_pluginConf[param] = "%X" % self.pluginConf[param]
+                        if isinstance( self.pluginConf[param], str):
+                            write_pluginConf[param] = "%X" % int(self.pluginConf[param],16)
+                        else:
+                            write_pluginConf[param] = "%X" % self.pluginConf[param]
                     else:
                         write_pluginConf[param] = self.pluginConf[param]
 

--- a/Classes/WebServer/onMessage.py
+++ b/Classes/WebServer/onMessage.py
@@ -6,6 +6,7 @@
 import mimetypes
 import os
 import os.path
+from pathlib import Path
 from datetime import datetime
 from time import gmtime, strftime
 from urllib.parse import urlparse
@@ -75,11 +76,13 @@ def onMessage(self, Connection, Data):
 
     else:
         # Finaly we simply has to serve a File.
-        webFilename = self.homedirectory + "www" + url
+        _homedir = Path( self.homedirectory )
+        webFilename = _homedir / ("www" + url)
         self.logging("Debug", "webFilename: %s" % webFilename)
         
     if not os.path.isfile(webFilename):
-        webFilename = self.homedirectory + "www" + "/z4d/index.html"
+        _homedir = Path( self.homedirectory )
+        webFilename = _homedir / "www/z4d/index.html"
         self.logging("Debug", "Redirecting to /z4d/index.html")
 
     # We are ready to send the response

--- a/Classes/ZigateTransport/handleProtocol.py
+++ b/Classes/ZigateTransport/handleProtocol.py
@@ -55,9 +55,7 @@ def process_frame(self, decoded_frame):
     if MsgType == "0302":  # PDM loaded, ZiGate ready (after an internal error, but also after an ErasePDM)
         self.logging_proto("Status", "ZiGate PDM loaded")
         if self.statistics.get_pdm_loaded() > 0:
-            self.logging_proto( "Error",
-                "Detected a PDM load, result of a ZiGate reset of (crash): #%s" % self.statistics.get_pdm_loaded(),
-            )
+            self.logging_proto( "Error", "Detected a PDM load, result of a ZiGate reset of (crash): #%s" % self.statistics.get_pdm_loaded(),)
         self.statistics.pdm_loaded()
 
         for x in list(self.ListOfCommands):

--- a/Classes/ZigateTransport/handleProtocol.py
+++ b/Classes/ZigateTransport/handleProtocol.py
@@ -169,34 +169,7 @@ def NXP_Extended_Error_Code(self, MsgData):
 
 def NXP_log_message(self, decoded_frame):  # Reception log Level
 
-    LOG_FILE = "ZiGate"
-
-    # self.logging_proto( 'Debug' , "8001 - %s" %decoded_frame )
-    MsgData = decoded_frame[12 : len(decoded_frame) - 2]
-    MsgLogLvl = MsgData[0:2]
-    try:
-        log_message = binascii.unhexlify(MsgData[2:]).decode("utf-8")
-    except:
-        log_message = binascii.unhexlify(MsgData[2:]).decode("utf-8", errors="ignore")
-        log_message = log_message.replace("\x00", "")
-
-    logfilename = self.pluginconf.pluginConf["pluginLogs"] + "/" + LOG_FILE + "_" + "%02d" % self.hardwareid + "_" + ".log"
-    try:
-        with open(logfilename, "at", encoding="utf-8") as file:
-            try:
-                if self.newline_required:
-                    file.write("\n%s %s" % (str(datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]), MsgLogLvl))
-                self.newline_required = False
-
-                file.write(" " + log_message)
-
-                if decoded_frame[len(decoded_frame) - 4 : len(decoded_frame) - 2] == "20":
-                    self.newline_required = True
-
-            except IOError:
-                self.logging_proto("Error", "Error while writing to ZiGate log file %s" % logfilename)
-    except IOError:
-        self.logging_proto("Error", "Error while Opening ZiGate log file %s" % logfilename)
+    return
 
 
 def Akila_debuging(self, MsgType, MsgData):

--- a/Classes/ZigpyTransport/instrumentation.py
+++ b/Classes/ZigpyTransport/instrumentation.py
@@ -5,6 +5,7 @@
 
 import time
 import os.path
+from pathlib import Path
 
 instrument_time = True
 
@@ -45,7 +46,7 @@ def open_capture_rx_frames(self):
     if "CaptureRxFrames" not in self.pluginconf.pluginConf or not self.pluginconf.pluginConf[ "CaptureRxFrames" ]:
         return
     
-    captureRxFrame_filename = self.pluginconf.pluginConf["pluginLogs"] + "/Capture-Zigbee-Rx-Frames-" + "%02d" % self.hardwareid + ".csv"
+    captureRxFrame_filename = Path( self.pluginconf.pluginConf["pluginLogs"]) / ("Capture-Zigbee-Rx-Frames-%02d.csv" % self.hardwareid)
     header = (
         None
         if os.path.isfile(captureRxFrame_filename)
@@ -60,7 +61,7 @@ def instrument_log_command_open( self):
     if "CaptureTxFrames" not in self.pluginconf.pluginConf or not self.pluginconf.pluginConf["CaptureTxFrames"]:
         return
     
-    captureTxFrame_filename = self.pluginconf.pluginConf["pluginLogs"] + "/Capture-Zigbee-Tx-Frames-" + "%02d" % self.hardwareid + ".csv"
+    captureTxFrame_filename = Path( self.pluginconf.pluginConf["pluginLogs"]) / ("Capture-Zigbee-Tx-Frames-%02d.csv" % self.hardwareid)
     header = (
         None
         if os.path.isfile(captureTxFrame_filename)

--- a/Modules/database.py
+++ b/Modules/database.py
@@ -12,6 +12,7 @@
 
 
 import json
+from pathlib import Path
 import os.path
 import time
 from typing import Dict
@@ -149,8 +150,9 @@ def LoadDeviceList(self):
         )
         res = "Success"
 
-    if os.path.isfile(self.pluginconf.pluginConf["pluginData"] + self.DeviceListName):
-        _DeviceListFileName = self.pluginconf.pluginConf["pluginData"] + self.DeviceListName
+    _pluginConf = Path( self.pluginconf.pluginConf["pluginData"] )
+    _DeviceListFileName = _pluginConf / self.DeviceListName
+    if os.path.isfile(_DeviceListFileName):
         res = loadTxtDatabase(self, _DeviceListFileName)
     else:
         # Do not exist
@@ -169,7 +171,7 @@ def LoadDeviceList(self):
             ),
         )
 
-    self.log.logging("Database", "Debug", "LoadDeviceList - DeviceList filename : " + _DeviceListFileName)
+    self.log.logging("Database", "Debug", "LoadDeviceList - DeviceList filename : %s" % _DeviceListFileName)
     Modules.tools.helper_versionFile(_DeviceListFileName, self.pluginconf.pluginConf["numDeviceListVersion"])
 
     # Keep the Size of the DeviceList in order to check changes
@@ -238,7 +240,7 @@ def LoadDeviceList(self):
 def loadTxtDatabase(self, dbName):
     res = "Success"
     with open(dbName, "r", encoding='utf-8') as myfile2:
-        self.log.logging("Database", "Debug", "Open : " + dbName)
+        self.log.logging("Database", "Debug", "Open : %s" % dbName)
         nb = 0
         for line in myfile2:
             if not line.strip():
@@ -361,7 +363,8 @@ def WriteDeviceList(self, count):  # sourcery skip: merge-nested-ifs
 
 def _write_DeviceList_txt(self):
     # Write in classic format ( .txt )
-    _DeviceListFileName = self.pluginconf.pluginConf["pluginData"] + self.DeviceListName
+    _pluginData = Path ( self.pluginconf.pluginConf["pluginData"] )
+    _DeviceListFileName = _pluginData / self.DeviceListName
     try:
         self.log.logging("Database", "Debug", "Write " + _DeviceListFileName + " = " + str(self.ListOfDevices))
         with open(_DeviceListFileName, "wt", encoding='utf-8') as file:
@@ -391,7 +394,8 @@ def _write_DeviceList_txt(self):
 
 
 def _write_DeviceList_json(self):
-    _DeviceListFileName = self.pluginconf.pluginConf["pluginData"] + self.DeviceListName[:-3] + "json"
+    _pluginData = Path ( self.pluginconf.pluginConf["pluginData"] )
+    _DeviceListFileName = _pluginData / self.DeviceListName[:-3] + "json"
     self.log.logging("Database", "Debug", "Write " + _DeviceListFileName + " = " + str(self.ListOfDevices))
     with open(_DeviceListFileName, "wt") as file:
         json.dump(self.ListOfDevices, file, sort_keys=True, indent=2)
@@ -410,9 +414,10 @@ def importDeviceConf(self):
     # Import DeviceConf.txt
     tmpread = ""
     self.DeviceConf = {}
-
-    if os.path.isfile(self.pluginconf.pluginConf["pluginConfig"] + "DeviceConf.txt"):
-        with open(self.pluginconf.pluginConf["pluginConfig"] + "DeviceConf.txt", "r") as myfile:
+    _pluginConfig = Path ( self.pluginconf.pluginConf["pluginConfig"] )
+    _DeviceConf = _pluginConfig / "DeviceConf.txt"
+    if os.path.isfile(_DeviceConf):
+        with open(_DeviceConf, "r") as myfile:
             tmpread += myfile.read().replace("\n", "")
             try:
                 self.DeviceConf = eval(tmpread)
@@ -441,8 +446,8 @@ def import_local_device_conf(self):
 
     # Read DeviceConf for backward compatibility
     importDeviceConf(self)
-
-    model_directory = self.pluginconf.pluginConf["pluginConfig"] + "Local-Devices"
+    _pluginConfig = Path( self.pluginconf.pluginConf["pluginConfig"] )
+    model_directory = _pluginConfig / "Local-Devices"
 
     if os.path.isdir(model_directory):
         model_list = [f for f in listdir(model_directory) if isfile(join(model_directory, f))]
@@ -451,7 +456,7 @@ def import_local_device_conf(self):
             if model_device in ("README.md", ".PRECIOUS"):
                 continue
 
-            filename = str(model_directory + "/" + model_device)
+            filename = model_directory / model_device
             with open(filename, "rt", encoding='utf-8') as handle:
                 try:
                     model_definition = json.load(handle)
@@ -561,8 +566,8 @@ def checkListOfDevice2Devices(self, Devices):
 
 
 def saveZigateNetworkData(self, nkwdata):
-
-    json_filename = self.pluginconf.pluginConf["pluginData"] + "Zigate.json"
+    _pluginData = Path( self.pluginconf.pluginConf["pluginConfig"] )
+    json_filename = _pluginData / "Zigate.json"
     self.log.logging("Database", "Debug", "Write " + json_filename + " = " + str(self.ListOfDevices))
     try:
         with open(json_filename, "wt", encoding='utf-8') as json_file:

--- a/Modules/database.py
+++ b/Modules/database.py
@@ -366,18 +366,20 @@ def _write_DeviceList_txt(self):
     _pluginData = Path ( self.pluginconf.pluginConf["pluginData"] )
     _DeviceListFileName = _pluginData / self.DeviceListName
     try:
-        self.log.logging("Database", "Debug", "Write " + _DeviceListFileName + " = " + str(self.ListOfDevices))
+        self.log.logging("Database", "Debug", "Write %s = %s" % (_DeviceListFileName, str(self.ListOfDevices)))
         with open(_DeviceListFileName, "wt", encoding='utf-8') as file:
             for key in self.ListOfDevices:
                 try:
                     file.write(key + " : " + str(self.ListOfDevices[key]) + "\n")
                     
                 except UnicodeEncodeError:
-                    self.log.logging( "Database", "Error", "UnicodeEncodeError while while saving %s : %s on file" %( key, self.ListOfDevices[key]))
+                    self.log.logging( "Database", "Error", "UnicodeEncodeError while while saving %s : %s on file" %( 
+                                                                                                                     key, self.ListOfDevices[key]))
                     continue
 
                 except ValueError:
-                    self.log.logging( "Database", "Error", "ValueError while saving %s : %s on file" %( key, self.ListOfDevices[key]))
+                    self.log.logging( "Database", "Error", "ValueError while saving %s : %s on file" %( 
+                                                                                                       key, self.ListOfDevices[key]))
                     continue
                 
                 except IOError:
@@ -396,7 +398,7 @@ def _write_DeviceList_txt(self):
 def _write_DeviceList_json(self):
     _pluginData = Path ( self.pluginconf.pluginConf["pluginData"] )
     _DeviceListFileName = _pluginData / self.DeviceListName[:-3] + "json"
-    self.log.logging("Database", "Debug", "Write " + _DeviceListFileName + " = " + str(self.ListOfDevices))
+    self.log.logging("Database", "Debug", "Write %s = %s" % (_DeviceListFileName, str(self.ListOfDevices)))
     with open(_DeviceListFileName, "wt") as file:
         json.dump(self.ListOfDevices, file, sort_keys=True, indent=2)
     self.log.logging("Database", "Debug", "WriteDeviceList - flush Plugin db to %s" % _DeviceListFileName)

--- a/Modules/readZclClusters.py
+++ b/Modules/readZclClusters.py
@@ -4,6 +4,7 @@ import json
 
 from os import listdir
 from os.path import isdir, isfile, join
+from pathlib import Path
 
 from DevicesModules import FUNCTION_MODULE, FUNCTION_WITH_ACTIONS_MODULE
 from Modules.domoMaj import MajDomoDevice
@@ -244,7 +245,7 @@ def _update_eval_formula( self, formula, input_variable, variable_name):
 
     
 def load_zcl_cluster(self):
-    zcl_cluster_path = self.pluginconf.pluginConf["pluginConfig"] + "ZclDefinitions"
+    zcl_cluster_path = Path( self.pluginconf.pluginConf["pluginConfig"]) / "ZclDefinitions"
     if not isdir(zcl_cluster_path):
         return
 
@@ -252,7 +253,7 @@ def load_zcl_cluster(self):
 
     zcl_cluster_definition = [f for f in listdir(zcl_cluster_path) if isfile(join(zcl_cluster_path, f))]
     for cluster_definition in sorted(zcl_cluster_definition):
-        cluster_filename = str(zcl_cluster_path + "/" + cluster_definition)
+        cluster_filename = zcl_cluster_path / cluster_definition
         cluster_definition = _read_zcl_cluster( self, cluster_filename )
 
         if (

--- a/Modules/readZclClusters.py
+++ b/Modules/readZclClusters.py
@@ -200,11 +200,15 @@ def _cluster_zcl_attribute_retrieval( self, cluster, attribute, parameter ):
     #self.log.logging("ZclClusters", "Debug", " . _cluster_zcl_attribute_retrieval %s %s %s" %(
         # cluster, attribute, parameter))
 
+    if cluster not in self.readZclClusters:
+        self.log.logging("ZclClusters", "Error", " . _cluster_zcl_attribute_retrieval %s not found in %s" %(
+            cluster, str(self.readZclClusters)))
+        return None
+    
     if (
         attribute in self.readZclClusters[ cluster ]["Attributes"] 
         and parameter in self.readZclClusters[ cluster ]["Attributes"][ attribute ]
     ):
-
         #self.log.logging("ZclClusters", "Debug", " . %s %s %s --> %s" %(
             # cluster, attribute, parameter, self.readZclClusters[ cluster ]["Attributes"][ attribute ][ parameter ])) 
         return self.readZclClusters[ cluster ]["Attributes"][ attribute ][ parameter ]

--- a/Modules/tools.py
+++ b/Modules/tools.py
@@ -13,6 +13,7 @@
 import datetime
 import time
 import os.path
+from pathlib import Path
 
 import Domoticz
 
@@ -1590,6 +1591,7 @@ def helper_copyfile(source, dest, move=True):
 
 def helper_versionFile(source, nbversion):
 
+    source = str(source)
     if nbversion == 0:
         return
 

--- a/Modules/zigpyBackup.py
+++ b/Modules/zigpyBackup.py
@@ -2,7 +2,7 @@
 import Domoticz
 import os.path
 import json
-
+from pathlib import Path
 import Modules.tools
 
 def handle_zigpy_backup(self, backup):
@@ -11,8 +11,8 @@ def handle_zigpy_backup(self, backup):
         self.log.logging("TransportZigpy", "Log","Backup is incomplete, it is not possible to restore")
         return
 
-    _coordinator_backup = self.pluginconf.pluginConf["pluginData"] + "/Coordinator-%02d" %self.HardwareID + ".backup"
-
+    _pluginData = Path( self.pluginconf.pluginConf["pluginData"] )
+    _coordinator_backup = _pluginData /  ("Coordinator-%02d" %self.HardwareID + ".backup")
     self.log.logging("TransportZigpy", "Debug", "Backups: %s" %backup)
 
     if os.path.exists(_coordinator_backup):
@@ -30,12 +30,13 @@ def handle_zigpy_backup(self, backup):
 def handle_zigpy_retreive_last_backup( self ):
     
     # Return the last backup
-    _coordinator_backup = self.pluginconf.pluginConf["pluginData"] + "/Coordinator-%02d" %self.HardwareID + ".backup"
+    _pluginData = Path( self.pluginconf.pluginConf["pluginData"] )
+    _coordinator_backup = _pluginData /  ("Coordinator-%02d" %self.HardwareID + ".backup")
     if not os.path.exists(_coordinator_backup):
         return None
 
     with open(_coordinator_backup, "r") as _coordinator:
-        self.log.logging("TransportZigpy", "Debug", "Open : " + _coordinator_backup)
+        self.log.logging("TransportZigpy", "Debug", "Open : %s" % _coordinator_backup)
         try:
             return json.load(_coordinator)
         except json.JSONDecodeError:

--- a/Modules/zigpyBackup.py
+++ b/Modules/zigpyBackup.py
@@ -12,7 +12,7 @@ def handle_zigpy_backup(self, backup):
         return
 
     _pluginData = Path( self.pluginconf.pluginConf["pluginData"] )
-    _coordinator_backup = _pluginData /  ("Coordinator-%02d" %self.HardwareID + ".backup")
+    _coordinator_backup = _pluginData /  ("Coordinator-%02d.backup" %self.HardwareID )
     self.log.logging("TransportZigpy", "Debug", "Backups: %s" %backup)
 
     if os.path.exists(_coordinator_backup):
@@ -31,7 +31,7 @@ def handle_zigpy_retreive_last_backup( self ):
     
     # Return the last backup
     _pluginData = Path( self.pluginconf.pluginConf["pluginData"] )
-    _coordinator_backup = _pluginData /  ("Coordinator-%02d" %self.HardwareID + ".backup")
+    _coordinator_backup = _pluginData /  ("Coordinator-%02d.backup" %self.HardwareID)
     if not os.path.exists(_coordinator_backup):
         return None
 

--- a/Modules/zigpyBackup.py
+++ b/Modules/zigpyBackup.py
@@ -12,7 +12,7 @@ def handle_zigpy_backup(self, backup):
         return
 
     _pluginData = Path( self.pluginconf.pluginConf["pluginData"] )
-    _coordinator_backup = _pluginData /  ("Coordinator-%02d.backup" %self.HardwareID )
+    _coordinator_backup = _pluginData / ("Coordinator-%02d.backup" %self.HardwareID )
     self.log.logging("TransportZigpy", "Debug", "Backups: %s" %backup)
 
     if os.path.exists(_coordinator_backup):
@@ -31,7 +31,7 @@ def handle_zigpy_retreive_last_backup( self ):
     
     # Return the last backup
     _pluginData = Path( self.pluginconf.pluginConf["pluginData"] )
-    _coordinator_backup = _pluginData /  ("Coordinator-%02d.backup" %self.HardwareID)
+    _coordinator_backup = _pluginData / ("Coordinator-%02d.backup" %self.HardwareID)
     if not os.path.exists(_coordinator_backup):
         return None
 

--- a/plugin.py
+++ b/plugin.py
@@ -328,7 +328,8 @@ class BasePlugin:
         self.pluginParameters = dict(Parameters)
 
         # Open VERSION file in .hidden
-        with open( os.path.join( Parameters["HomeFolder"], VERSION_FILENAME), "rt") as versionfile:
+        version_filename = pathlib.Path(Parameters["HomeFolder"]) / VERSION_FILENAME
+        with open( version_filename, "rt") as versionfile:
             try:
                 _pluginversion = json.load(versionfile)
             except Exception as e:

--- a/plugin.py
+++ b/plugin.py
@@ -87,10 +87,10 @@ try:
     from Domoticz import Devices, Images, Parameters, Settings
 except ImportError:
     pass
-
 import gc
 import json
 import os
+import os.path
 import threading
 import time
 from importlib.metadata import version as import_version
@@ -328,7 +328,7 @@ class BasePlugin:
         self.pluginParameters = dict(Parameters)
 
         # Open VERSION file in .hidden
-        with open(Parameters["HomeFolder"] + VERSION_FILENAME, "rt") as versionfile:
+        with open( os.path.join( Parameters["HomeFolder"], VERSION_FILENAME), "rt") as versionfile:
             try:
                 _pluginversion = json.load(versionfile)
             except Exception as e:
@@ -565,7 +565,8 @@ class BasePlugin:
         elif self.transport == "ZigpyZNP":
             import zigpy
             import zigpy_znp
-            from zigpy.config import (CONF_DEVICE, CONF_DEVICE_PATH, CONFIG_SCHEMA, SCHEMA_DEVICE)
+            from zigpy.config import (CONF_DEVICE, CONF_DEVICE_PATH,
+                                      CONFIG_SCHEMA, SCHEMA_DEVICE)
 
             from Classes.ZigpyTransport.Transport import ZigpyTransport
 
@@ -585,7 +586,8 @@ class BasePlugin:
         elif self.transport == "ZigpydeCONZ":
             import zigpy
             import zigpy_deconz
-            from zigpy.config import (CONF_DEVICE, CONF_DEVICE_PATH, CONFIG_SCHEMA, SCHEMA_DEVICE)
+            from zigpy.config import (CONF_DEVICE, CONF_DEVICE_PATH,
+                                      CONFIG_SCHEMA, SCHEMA_DEVICE)
 
             from Classes.ZigpyTransport.Transport import ZigpyTransport
 
@@ -601,7 +603,8 @@ class BasePlugin:
         elif self.transport == "ZigpyEZSP":
             import bellows
             import zigpy
-            from zigpy.config import (CONF_DEVICE, CONF_DEVICE_PATH, CONFIG_SCHEMA, SCHEMA_DEVICE)
+            from zigpy.config import (CONF_DEVICE, CONF_DEVICE_PATH,
+                                      CONFIG_SCHEMA, SCHEMA_DEVICE)
 
             from Classes.ZigpyTransport.Transport import ZigpyTransport
 
@@ -1494,7 +1497,8 @@ def check_requirements( self ):
 
     import pkg_resources
 
-    _filename = pathlib.Path( Parameters[ "HomeFolder"] + "requirements.txt" )
+    _homefolder = pathlib.Path( Parameters[ "HomeFolder"] )
+    _filename = _homefolder / "requirements.txt"
 
     Domoticz.Status("Checking Python modules %s" %_filename)
     requirements = pkg_resources.parse_requirements(_filename.open())
@@ -1610,7 +1614,8 @@ def install_Z4D_to_domoticz_custom_ui():
     #line5 = 'document.getElementById(\'%s\').src' %Parameters['Name'] + ' = location.protocol + "/z4d/";\n' 
     line6 = '</script>\n'
 
-    custom_file = Parameters['StartupFolder'] + 'www/templates/' + f"{Parameters['Name']}" + '.html'
+    _startupfolder = pathlib.Path( Parameters['StartupFolder'] )
+    custom_file = _startupfolder / 'www/templates' / f"{Parameters['Name']}.html"
     Domoticz.Log(f"Installing plugin custom page {custom_file} ")
 
     try:


### PR DESCRIPTION
Refactor the all path and filename management and rely on the pathlib.Path method
This should help in addressing Linux vs. Windows issues

This module offers classes representing filesystem paths with semantics appropriate for different operating systems

 #1570