### PR TITLE
Zlinky - Remove string conversion

### DIFF
--- a/DevicesModules/custom_zlinky.py
+++ b/DevicesModules/custom_zlinky.py
@@ -168,13 +168,9 @@ def zlinky_cluster_metering(self, Devices, nwkid, ep, cluster, attribut, value):
         store_ZLinky_infos( self, nwkid, 'EASF10', value)
 
     elif attribut == "0307":  # PRM
-        try:
-            store_ZLinky_infos( self, nwkid, 'PRM', binascii.unhexlify(value).decode("utf-8"))
-        except Exception as e:
-            store_ZLinky_infos( self, nwkid, 'PRM', value)
+        store_ZLinky_infos( self, nwkid, 'PRM', value)
         
     elif attribut == "0308":  # Serial Number
-        value = binascii.unhexlify(value).decode("utf-8")
         self.log.logging( "ZLinky", "Debug", "Cluster0702 - 0x0308 - Serial Number %s" % (value), nwkid, )
         
         checkAndStoreAttributeValue(self, nwkid, ep, cluster, attribut, value)


### PR DESCRIPTION
String conversion is already done in the ZCL decode layer