### PR TITLE
Upgrade of zigpy radio libs to a more recent version 

### DIFF
--- a/Classes/ZigpyTransport/zigpyThread.py
+++ b/Classes/ZigpyTransport/zigpyThread.py
@@ -276,10 +276,9 @@ def post_coordinator_startup(self, radiomodule):
 
     self.log.logging( "TransportZigpy", "Debug", "Active Endpoint List:  %s" % str(self.app.get_device(nwk=t.NWK(0x0000)).endpoints.keys()), )
     for epid, ep in self.app.get_device(nwk=t.NWK(0x0000)).endpoints.items():
-        if epid == 0:
-            continue
-        self.log.logging( "TransportZigpy", "Debug", "Simple Descriptor:  %s" % ep)
-        self.forwarder_queue.put(build_plugin_8043_frame_list_node_descriptor(self, epid, ep))
+        if epid != 0 and ep.status == 0x00:
+            self.log.logging( "TransportZigpy", "Debug", "Simple Descriptor:  %s" % ep)
+            self.forwarder_queue.put(build_plugin_8043_frame_list_node_descriptor(self, epid, ep))
 
     self.log.logging( "TransportZigpy", "Debug", "Controller Model %s" % self.app.get_device(nwk=t.NWK(0x0000)).model )
     self.log.logging( "TransportZigpy", "Debug", "Controller Manufacturer %s" % self.app.get_device(nwk=t.NWK(0x0000)).manufacturer )

--- a/plugin.py
+++ b/plugin.py
@@ -1505,7 +1505,7 @@ def check_python_modules_version( self ):
         "zigpy": "0.58.1",
         "zigpy_znp": "0.11.6",
         "zigpy_deconz": "0.21.1",
-        "bellows": "0.36.7",
+        "bellows": "0.36.8",
         }
 
     flag = True

--- a/plugin.py
+++ b/plugin.py
@@ -1502,10 +1502,10 @@ def update_DB_device_status_to_reinit( self ):
 def check_python_modules_version( self ):
     
     MODULES_VERSION = {
-        "zigpy": "0.58.0",
+        "zigpy": "0.58.1",
         "zigpy_znp": "0.11.6",
         "zigpy_deconz": "0.21.1",
-        "bellows": "0.36.1",
+        "bellows": "0.36.7",
         }
 
     flag = True

--- a/plugin.py
+++ b/plugin.py
@@ -1502,10 +1502,10 @@ def update_DB_device_status_to_reinit( self ):
 def check_python_modules_version( self ):
     
     MODULES_VERSION = {
-        "zigpy": "0.56.1",
-        "zigpy_znp": "0.11.2",
-        "zigpy_deconz": "0.21.0",
-        "bellows": "0.35.8",
+        "zigpy": "0.58.0",
+        "zigpy_znp": "0.11.6",
+        "zigpy_deconz": "0.21.1",
+        "bellows": "0.36.1",
         }
 
     flag = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-bellows==0.35.8
+bellows==0.36.5
 dnspython==2.3.0
 pyserial>=3.5
 z4d-certified-devices
-zigpy==0.56.1
-zigpy_deconz==0.21.0
-zigpy_znp==0.11.2
+zigpy==0.58.0
+zigpy_deconz==0.21.1
+zigpy_znp==0.11.6
 charset-normalizer==2.0.11
 distro
 zigpy-cli==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-bellows==0.36.5
+zigpy==0.58.1
+zigpy_deconz==0.21.1
+zigpy-cli==1.0.4
+zigpy_znp==0.11.6
+bellows==0.36.7
 dnspython==2.3.0
 pyserial>=3.5
 z4d-certified-devices
-zigpy==0.58.0
-zigpy_deconz==0.21.1
-zigpy_znp==0.11.6
 charset-normalizer==2.0.11
 distro
-zigpy-cli==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ zigpy==0.58.1
 zigpy_deconz==0.21.1
 zigpy-cli==1.0.4
 zigpy_znp==0.11.6
-bellows==0.36.7
+bellows==0.36.8
 dnspython==2.3.0
 pyserial>=3.5
 z4d-certified-devices


### PR DESCRIPTION
- [x] bellows==0.36.8
- [x] zigpy==0.58.1
- [x] zigpy_deconz==0.21.1
- [x] zigpy_znp==0.11.6
