### PR TITLE
Modules/pluginModels.py: Add LIDL plug model A2

### DIFF
--- a/Modules/pluginModels.py
+++ b/Modules/pluginModels.py
@@ -109,7 +109,7 @@ PLUGIN_MODELS_MATRIX = [
             '_TZ3000_amdymr7l', '_TZ3000_z1pnpsdo', '_TZ3000_ksw8qtmt', '_TZ3000_nzkqcvvs', 
             '_TZ3000_1h2x4akh', '_TZ3000_9vo5icau', '_TZ3000_cehuw1lw', '_TZ3000_ko6v90pg', 
             '_TZ3000_f1bapcit', '_TZ3000_cjrngdr3', '_TZ3000_zloso4jk', '_TZ3000_r6buo8ba', 
-            '_TZ3000_iksasdbv', '_TZ3000_dd8wwzcy', '_TZ3000_hdopuwv6'],
+            '_TZ3000_iksasdbv', '_TZ3000_dd8wwzcy', '_TZ3000_hdopuwv6', '_TZ3000_ynmowqk2'],
         "ManufId": [],
         "PluginModelName": "TS011F-plug" },
     


### PR DESCRIPTION
Bought recently this plug with power consumption support from LIDL. Add missing identifier to get it properly reporting power usage.