### PR TITLE
Modules/input.py: Decode8095: Fix fallback MsgCmd

### DIFF
--- a/Modules/input.py
+++ b/Modules/input.py
@@ -4140,7 +4140,7 @@ def Decode8095(self, Devices, MsgData, MsgLQI):
             MajDomoDevice(self, Devices, MsgSrcAddr, "02", "0006", "01")
         
     else:
-        MajDomoDevice(self, Devices, MsgSrcAddr, MsgEP, "0006", str(int(MsgCmd, 16)))
+        MajDomoDevice(self, Devices, MsgSrcAddr, MsgEP, "0006", MsgCmd)
         self.ListOfDevices[MsgSrcAddr]["Ep"][MsgEP][MsgClusterId]["0000"] = "Cmd: %s, %s" % (MsgCmd, unknown_)
         self.log.logging( "Input", "Log", "Decode8095 - Model: %s SQN: %s, Addr: %s, Ep: %s, Cluster: %s, Cmd: %s, Unknown: %s " % (
             _ModelName, MsgSQN, MsgSrcAddr, MsgEP, MsgClusterId, MsgCmd, unknown_), MsgSrcAddr, )


### PR DESCRIPTION
Dont use str(int(MsgCmd, 16)) as MsgCmd will be converted from "01" to "1" for instance.