### PR TITLE
zclCluster decode the value as an int for the 01ZBMINI

### DIFF
--- a/Modules/switchSelectorWidgets.py
+++ b/Modules/switchSelectorWidgets.py
@@ -606,7 +606,9 @@ SWITCH_SELECTORS = {
     },
     "Switch": {
         "00": (0, "Off"),
+        0: (0, "Off"),
         "01": (1, "On"),
+        1: (1, "On"),
         "ForceUpdate": False
     },
     "SwitchAQ2": {


### PR DESCRIPTION
01ZBMINI report attribute 0x0000 cluster 0x0006 as datatype 0x28 instead of 0x10
consequently the attribute is not decoded as expected.

The PR allow the "Switch" WidgetType to allow "01" and 1 for On , "00", 0 for Off