### PR TITLE
Fix schneider zoning path file

### DIFF
--- a/Modules/schneider_wiser.py
+++ b/Modules/schneider_wiser.py
@@ -1453,7 +1453,7 @@ def importSchneiderZoning(self):
 
     SCHNEIDER_ZONING = "schneider_zoning.json"
 
-    self.SchneiderZoningFilename = self.pluginconf.pluginConf["pluginConfig"] + SCHNEIDER_ZONING
+    self.SchneiderZoningFilename = self.pluginconf.pluginConf["pluginConfig"] + os.sep + SCHNEIDER_ZONING
 
     if not os.path.isfile(self.SchneiderZoningFilename):
         self.log.logging("Schneider", "Debug", f"importSchneiderZoning - Nothing to import from {self.SchneiderZoningFilename}")


### PR DESCRIPTION
I am not sure what happened there. It seems the config file have folder with no separator at the end on my config. Hence the file could not be found as it was looking for
/folderschneider_zoning.json