### PR TITLE
Use zigpy OTA instead of plugin OTA to update device firmwares

### DIFF
--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -208,6 +208,8 @@ SETTINGS = {
             "pluginData": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
             "pluginConfig": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
             "pluginOTAFirmware": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
+            "zigpyOTArepository": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
+            
             "pluginReports": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
             "pluginWWW": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
             "pluginLogs": {"type": "path","default": "","current": None,"restart": 1,"hidden": False,"Advanced": True,},
@@ -718,6 +720,8 @@ def setup_folder_parameters(self, homedir):
                 self.pluginConf[param] = str( Path(self.pluginConf["pluginHome"]) / "Logs")
             elif param == "pluginOTAFirmware":
                 self.pluginConf[param] = str( Path(self.pluginConf["pluginHome"]) / "OTAFirmware")
+            elif param == "zigpyOTArepository":
+                self.pluginConf[param] = str( Path(self.pluginConf["pluginHome"]) / "zigpyOTArepository")
             elif param == "pluginReports":
                 self.pluginConf[param] = str( Path(self.pluginConf["pluginHome"]) / "Reports")
             elif param == "pluginWWW":

--- a/Classes/ZigpyTransport/AppGeneric.py
+++ b/Classes/ZigpyTransport/AppGeneric.py
@@ -408,6 +408,11 @@ def packet_received(
         super(type(self),self).packet_received(packet)
         return
 
+    if cluster == 0x0019:
+        # forward message to zigpy
+        super(type(self),self).packet_received(packet)
+        return
+
     packet.lqi = 0x00 if packet.lqi is None else packet.lqi
     profile = 0x0000 if src_ep == dst_ep == 0x00 else profile
 
@@ -418,10 +423,6 @@ def packet_received(
     plugin_frame = build_plugin_8002_frame_content(self, sender, profile, cluster, src_ep, dst_ep, message, packet.lqi, src_addrmode=addr_mode)
     self.log.logging("TransportZigpy", "Debug", "packet_received Sender: %s frame for plugin: %s" % (sender, plugin_frame))
     self.callBackFunction(plugin_frame)
-
-    if cluster == 0x0019:
-        # Do not forward message to zigpy
-        return
 
     super(type(self),self).packet_received(packet)
     

--- a/Classes/ZigpyTransport/AppGeneric.py
+++ b/Classes/ZigpyTransport/AppGeneric.py
@@ -161,6 +161,10 @@ async def initialize(self, *, auto_form: bool = False, force_form: bool = False)
         # Config specifies the period in minutes, not seconds
         self.topology.start_periodic_scans( period=(60 * self.config[zigpy.config.CONF_TOPO_SCAN_PERIOD]) )
 
+    if ( self.config[zigpy_conf.CONF_OTA][zigpy_conf.CONF_OTA_ENABLED] and self.config[zigpy_conf.CONF_OTA][zigpy_conf.CONF_OTA_BROADCAST_ENABLED] ):
+            self.log.logging("TransportZigpy", "Status", "Starting up OTA notification broadcast with initial delay of % sec" %zigpy_conf.CONF_OTA_BROADCAST_INITIAL_DELAY)
+            self.ota.start_periodic_broadcasts( initial_delay=self._config[zigpy_conf.CONF_OTA][zigpy_conf.CONF_OTA_BROADCAST_INITIAL_DELAY], interval=self._config[zigpy_conf.CONF_OTA][zigpy_conf.CONF_OTA_BROADCAST_INTERVAL], )
+
 
 async def shutdown(self) -> None:
     """Shutdown controller."""

--- a/Classes/ZigpyTransport/zigpyThread.py
+++ b/Classes/ZigpyTransport/zigpyThread.py
@@ -273,9 +273,20 @@ def optional_configuration_setup(self, config, conf, set_extendedPanId, set_chan
     # Enable or not Source Routing based on zigpySourceRouting setting
     config[zigpy.config.CONF_SOURCE_ROUTING] = bool( self.pluginconf.pluginConf["zigpySourceRouting"] )
     
-    # Disable Zigpy OTA
-    config[zigpy.config.CONF_OTA][zigpy.config.CONF_OTA_ENABLED] = False
-    
+    # Enable Zigpy OTA
+    config[zigpy.config.CONF_OTA] = {
+        zigpy.config.CONF_OTA_ENABLED: True,
+        zigpy.config.CONF_OTA_BROADCAST_ENABLED: False,
+        zigpy.config.CONF_OTA_EXTRA_PROVIDERS: [
+            {
+                zigpy.config.CONF_OTA_PROVIDER_TYPE: "advanced",
+                zigpy.config.CONF_OTA_PROVIDER_PATH: Path( self.pluginconf.pluginConf["zigpyOTArepository"]),
+                zigpy.config.CONF_OTA_PROVIDER_WARNING: zigpy.config.CONF_OTA_ALLOW_ADVANCED_DIR_STRING,
+            },
+        ],
+    }
+
+   
     # Disable zigpy conf topo scan by default
     config[zigpy.config.CONF_TOPO_SCAN_ENABLED] = False
 

--- a/Classes/ZigpyTransport/zigpyThread.py
+++ b/Classes/ZigpyTransport/zigpyThread.py
@@ -276,12 +276,24 @@ def optional_configuration_setup(self, config, conf, set_extendedPanId, set_chan
     # Enable Zigpy OTA
     config[zigpy.config.CONF_OTA] = {
         zigpy.config.CONF_OTA_ENABLED: True,
-        zigpy.config.CONF_OTA_BROADCAST_ENABLED: False,
+        zigpy.config.CONF_OTA_BROADCAST_ENABLED: True,
+        zigpy.config.CONF_OTA_BROADCAST_INITIAL_DELAY: 60,
+        zigpy.config.CONF_OTA_BROADCAST_INTERVAL: 300,
+        zigpy.config.CONF_OTA_IKEA: True,
+        zigpy.config.CONF_OTA_INOVELLI: True,
+        zigpy.config.CONF_OTA_LEDVANCE: True,
+        zigpy.config.CONF_OTA_SALUS: True,
+        zigpy.config.CONF_OTA_SONOFF: True,
+        zigpy.config.CONF_OTA_THIRDREALITY: True,
         zigpy.config.CONF_OTA_EXTRA_PROVIDERS: [
             {
                 zigpy.config.CONF_OTA_PROVIDER_TYPE: "advanced",
                 zigpy.config.CONF_OTA_PROVIDER_PATH: Path( self.pluginconf.pluginConf["zigpyOTArepository"]),
                 zigpy.config.CONF_OTA_PROVIDER_WARNING: zigpy.config.CONF_OTA_ALLOW_ADVANCED_DIR_STRING,
+            },
+            {
+                zigpy.config.CONF_OTA_PROVIDER_TYPE: "z2m",
+                zigpy.config.CONF_OTA_PROVIDER_URL: "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/index.json",
             },
         ],
     }

--- a/Classes/ZigpyTransport/zigpyThread.py
+++ b/Classes/ZigpyTransport/zigpyThread.py
@@ -279,13 +279,23 @@ def optional_configuration_setup(self, config, conf, set_extendedPanId, set_chan
         zigpy.config.CONF_OTA_BROADCAST_ENABLED: True,
         zigpy.config.CONF_OTA_BROADCAST_INITIAL_DELAY: 60,
         zigpy.config.CONF_OTA_BROADCAST_INTERVAL: 300,
-        zigpy.config.CONF_OTA_IKEA: True,
-        zigpy.config.CONF_OTA_INOVELLI: True,
-        zigpy.config.CONF_OTA_LEDVANCE: True,
         zigpy.config.CONF_OTA_SALUS: True,
-        zigpy.config.CONF_OTA_SONOFF: True,
-        zigpy.config.CONF_OTA_THIRDREALITY: True,
         zigpy.config.CONF_OTA_EXTRA_PROVIDERS: [
+            {
+                zigpy.config.CONF_OTA_PROVIDER_TYPE: "ikea",
+            },
+            {
+                zigpy.config.CONF_OTA_PROVIDER_TYPE: "inovelli",
+            },
+            {
+                zigpy.config.CONF_OTA_PROVIDER_TYPE: "ledvance",
+            },
+            {
+                zigpy.config.CONF_OTA_PROVIDER_TYPE: "sonoff",
+            },
+            {
+                zigpy.config.CONF_OTA_PROVIDER_TYPE: "thirdreality",
+            },
             {
                 zigpy.config.CONF_OTA_PROVIDER_TYPE: "advanced",
                 zigpy.config.CONF_OTA_PROVIDER_PATH: Path( self.pluginconf.pluginConf["zigpyOTArepository"]),
@@ -293,11 +303,9 @@ def optional_configuration_setup(self, config, conf, set_extendedPanId, set_chan
             },
             {
                 zigpy.config.CONF_OTA_PROVIDER_TYPE: "z2m",
-                zigpy.config.CONF_OTA_PROVIDER_URL: "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/index.json",
             },
         ],
     }
-
    
     # Disable zigpy conf topo scan by default
     config[zigpy.config.CONF_TOPO_SCAN_ENABLED] = False


### PR DESCRIPTION
- [ ] configure zigpy OTA in the zigpy transport
- [x] define zigoy-OTA-firmware repository
- [ ] update WebUI to retreive available firmware and display then correctly
- [ ] allow to notify firmware availability via the WebUI
- [ ] makes the OTA running