### PR TITLE
request a plugin restart after 8 communication lost

### DIFF
--- a/Classes/ZigpyTransport/AppBellows.py
+++ b/Classes/ZigpyTransport/AppBellows.py
@@ -65,6 +65,7 @@ class App_bellows(bellows.zigbee.application.ControllerApplication):
 
         self.shutting_down = False
         self.restarting = False
+        self.radio_lost_cnt = 0
 
         try:
             await self.connect()

--- a/Classes/ZigpyTransport/AppDeconz.py
+++ b/Classes/ZigpyTransport/AppDeconz.py
@@ -62,6 +62,7 @@ class App_deconz(zigpy_deconz.zigbee.application.ControllerApplication):
 
         self.shutting_down = False
         self.restarting = False
+        self.radio_lost_cnt = 0
 
         await asyncio.sleep( 3 )
 

--- a/Classes/ZigpyTransport/AppGeneric.py
+++ b/Classes/ZigpyTransport/AppGeneric.py
@@ -160,10 +160,15 @@ async def _create_backup(self) -> None:
 def connection_lost(self, exc: Exception) -> None:
     """Handle connection lost event."""
     LOGGER.warning( "+ Connection to the radio was lost (trying to recover): %s %r" %(type(exc), exc) )
+    self.radio_lost_cnt += 1
 
     super(type(self),self).connection_lost(exc)
 
-    if not self.shutting_down and not self.restarting and isinstance( exc, serial.serialutil.SerialException):
+    if self.radio_lost_cnt > 8:
+        LOGGER.error( "++++++++++++++++++++++ Connection to coordinator failed too many errors, let's restart the plugin")
+        self.callBackRestartPlugin()
+    
+    elif not self.shutting_down and not self.restarting and isinstance( exc, serial.serialutil.SerialException):
         LOGGER.error( "++++++++++++++++++++++ Connection to coordinator failed on Serial, let's restart the plugin")
         LOGGER.warning( f"--> : self.shutting_down: {self.shutting_down}, {self.restarting}")
 

--- a/Classes/ZigpyTransport/AppZnp.py
+++ b/Classes/ZigpyTransport/AppZnp.py
@@ -66,6 +66,7 @@ class App_znp(zigpy_znp.zigbee.application.ControllerApplication):
 
         self.shutting_down = False
         self.restarting = False
+        self.radio_lost_cnt = 0
 
         # Pipiche : 24-Oct-2022 Disabling CONF_MAX_CONCURRENT_REQUESTS so the default will be used ( 16 )
         # self.znp_config[znp_conf.CONF_MAX_CONCURRENT_REQUESTS] = 2

--- a/Classes/ZigpyTransport/zigpyThread.py
+++ b/Classes/ZigpyTransport/zigpyThread.py
@@ -825,6 +825,7 @@ async def _send_and_retry(self, Function, destination, Profile, Cluster, _nwkid,
         try:
             self.log.logging("TransportZigpy", "Debug", f"_send_and_retry: {_ieee} {Profile:X} {Cluster:X} - AckIsDisable: {ack_is_disable} extended_timeout: {extended_timeout} Attempts: {attempt}/{max_retry}")
             result, _ = await zigpy_request(self, destination, Profile, Cluster, sEp, dEp, sequence, payload, ack_is_disable=ack_is_disable, use_ieee=use_ieee, extended_timeout=extended_timeout)
+            self.radio_lost_cnt = 0
 
         except (asyncio.exceptions.TimeoutError, asyncio.exceptions.CancelledError, AttributeError, DeliveryError) as e:
             error_log_message = f"Warning while submitting - {Function} {_ieee}/0x{_nwkid} 0x{Profile:X} 0x{Cluster:X} payload: {payload} AckIsDisable: {ack_is_disable} Retry: {attempt}/{max_retry} with exception: '{e}' ({type(e)}))"
@@ -844,6 +845,7 @@ async def _send_and_retry(self, Function, destination, Profile, Cluster, _nwkid,
             error_log_message = f"_send_and_retry - Unexpected Exception - {Function} {_ieee}/0x{_nwkid} 0x{Profile:X} 0x{Cluster:X} payload: {payload} AckIsDisable: {ack_is_disable} RETRY: {attempt}/{max_retry} ({error})"
             self.log.logging("TransportZigpy", "Error", error_log_message)
             result = 0xB6
+            break
 
         else:
             # Success


### PR DESCRIPTION
zigpy do not handle the lost of connection on the serial line.
The purpose here is not to be to aggressive and to wait for 8 connection lost messages before restarting the plugin instance.
As soon as we have an outgoing connection to the coordinator successful, the counter is reset to 0