### PR TITLE
Fix code scanning alert no. 1: Use of insecure SSL/TLS version

### DIFF
--- a/Classes/WebServer/com.py
+++ b/Classes/WebServer/com.py
@@ -352,6 +352,8 @@ def run_server(self, host='0.0.0.0', port=9440):   # nosec
         self.logging( "Log", f"++ WebUI - SSL Private key {server_private_key}")
 
         context = check_cert_and_key(self, server_certificate, server_private_key)
+        if context:
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
 
         if context:
             self.server = context.wrap_socket( self.server, server_side=True, )


### PR DESCRIPTION
Fixes [https://github.com/zigbeefordomoticz/Domoticz-Zigbee/security/code-scanning/1](https://github.com/zigbeefordomoticz/Domoticz-Zigbee/security/code-scanning/1)

To fix the problem, we need to ensure that the `ssl.SSLContext` is configured to use a secure protocol, specifically TLS 1.2 or above. This can be done by setting the `minimum_version` attribute of the `SSLContext` to `ssl.TLSVersion.TLSv1_2`. This change should be made when the `SSLContext` is created to ensure that only secure protocols are used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
