### PR TITLE
 sonoff smart valve, the attributes needs to be not manuf specific to work

### DIFF
--- a/DevicesModules/custom_sonoff.py
+++ b/DevicesModules/custom_sonoff.py
@@ -66,19 +66,19 @@ def sonoff_temp_humi_ranges(self, nwkid, value):
 def sonoff_realtime_irrigation_duration(self, nwkid, value):
     """ Real-time Irrigation duration """
     self.log.logging("Sonoff", "Debug", "sonoff_realtime_irrigation_duration - Nwkid: %s value: %s" % (nwkid, value), nwkid)
-    write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "01", SONOFF_REALTIME_IRRIGATION_DURATION, "23", "%08x" %value, ackIsDisabled=False)
+    write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "00", SONOFF_REALTIME_IRRIGATION_DURATION, "23", "%08x" %value, ackIsDisabled=False)
 
 
 def sonoff_realtime_irrigation_volume(self, nwkid, value):
     """ Real-time Irrigation volume """
     self.log.logging("Sonoff", "Debug", "sonoff_realtime_irrigation_duration - Nwkid: %s value: %s" % (nwkid, value), nwkid)
-    write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "01", SONOFF_REALTIME_IRRIGATION_VOLUME, "23", "%08x" %value, ackIsDisabled=False)
+    write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "00", SONOFF_REALTIME_IRRIGATION_VOLUME, "23", "%08x" %value, ackIsDisabled=False)
 
 
 def sonoff_realtime_irrigation_daily_volume(self, nwkid, value):
     """ Daily irigation volume """
     self.log.logging("Sonoff", "Debug", "sonoff_realtime_irrigation_duration - Nwkid: %s value: %s" % (nwkid, value), nwkid)
-    write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "01", SONOFF_DAILY_IRRIGATION_VOLUME, "23", "%08x" %value, ackIsDisabled=False)
+    write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "00", SONOFF_DAILY_IRRIGATION_VOLUME, "23", "%08x" %value, ackIsDisabled=False)
 
 
 def auto_close_when_water_shortage(self, nwkid, value):
@@ -86,7 +86,7 @@ def auto_close_when_water_shortage(self, nwkid, value):
 
     self.log.logging("Sonoff", "Debug", "auto_close_when_water_shortage - Nwkid: %s value: %s" % (nwkid, value), nwkid)
     water_close_valve_timeout = "%04x" % value
-    write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "01", SONOFF_WATER_CLOSE_VALVE_TIMEOUT_ATTRIBUTE, "21", water_close_valve_timeout, ackIsDisabled=False)
+    write_attribute(self, nwkid, ZIGATE_EP, "01", SONOFF_CLUSTER_ID, SONOFF_MANUFACTURER_ID, "00", SONOFF_WATER_CLOSE_VALVE_TIMEOUT_ATTRIBUTE, "21", water_close_valve_timeout, ackIsDisabled=False)
 
 
 def zbmicro_radio_power_turbo_mode(self, nwkid, mode):


### PR DESCRIPTION
 the attributes needs to be send in NON manufacturer specific, otherwise we get an error stating that the attributes is unkown

Moreover, in order to deactivate the 30mins timeout (SONOFF_WATER_CLOSE_VALVE_TIMEOUT_ATTRIBUTE) when no water is detected (if the water flow is 0), you need to upgrade the device to firmware 1.0.4