### PR TITLE
Introduce ThreadSafeDeviceDict — thread-safe mapping for ListOfDevices, IEEE2NWK, and ListOfDomoticzWidget

### DIFF
--- a/Classes/ThreadSafeDeviceDict.py
+++ b/Classes/ThreadSafeDeviceDict.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Implementation of Zigbee for Domoticz plugin.
+#
+# This file is part of Zigbee for Domoticz plugin. https://github.com/zigbeefordomoticz/Domoticz-Zigbee
+# (C) 2015-2026
+#
+# Initial authors: pipiche38
+#
+
+
+"""
+ThreadSafeDeviceDict.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Provides ThreadSafeDeviceDict, a thread-safe dict-like container intended
+for use as a drop-in replacement for plain dicts such as ListOfDevices,
+IEEE2NWK, and ListOfDomoticzWidget in zigbeefordomoticz.
+
+Each instance owns its own RLock.  Inner dicts are auto-wrapped on
+assignment, so nested writes like::
+
+    self.ListOfDevices[nwkid]["battery"] = 90
+
+are protected without any extra effort from the caller.
+
+Debugging
+---------
+Set the module-level flag ``TSDD_DEBUG = True`` (or call
+``ThreadSafeDeviceDict.set_debug(True)`` at runtime) to enable per-call
+trace logging on every method.  Each log line includes:
+ 
+* timestamp
+* thread name + id
+* instance id (so you can distinguish ListOfDevices from IEEE2NWK)
+* method name, arguments, and return value (or exception)
+* wall-clock duration in microseconds
+ 
+When ``TSDD_DEBUG`` is ``False`` (the default) the decorator adds no
+measurable overhead — the check is a single boolean read.
+"""
+
+import functools
+import logging
+import threading
+import time
+import traceback
+from collections.abc import MutableMapping
+from contextlib import contextmanager
+
+# ---------------------------------------------------------------------------
+# Debug flag — flip to True to enable trace logging, or call
+# ThreadSafeDeviceDict.set_debug(True) at runtime.
+# ---------------------------------------------------------------------------
+TSDD_DEBUG: bool = True
+ 
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Debug decorator
+# ---------------------------------------------------------------------------
+ 
+def _tsdd_trace(method):
+    """Wrap *method* with optional debug-trace logging.
+ 
+    The wrapper checks the module-level ``TSDD_DEBUG`` flag on **every
+    call**.  When the flag is ``False`` the check is a single boolean read
+    and control falls through to the real method immediately — no string
+    formatting, no logging, negligible overhead.
+ 
+    When ``TSDD_DEBUG`` is ``True`` each call emits one ``DEBUG`` line via
+    the module logger (``logging.getLogger(__name__)``), e.g.::
+ 
+        [TSDD] 2024-01-15 12:00:01.042 | Thread-3(140234) | id=0x7f3a |
+               __setitem__('1234', {'battery': 90}) -> None  [38.4 µs]
+ 
+    Exceptions are logged (with full traceback) then re-raised unchanged so
+    normal error handling is unaffected.
+ 
+    Args:
+        method: Any instance method of :class:`ThreadSafeDeviceDict`.
+ 
+    Returns:
+        A :func:`functools.wraps`-preserving wrapper around *method*.
+    """
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if not TSDD_DEBUG:
+            # Fast path — zero extra work in production.
+            return method(self, *args, **kwargs)
+ 
+        thread = threading.current_thread()
+        name = method.__name__
+        id_str = hex(id(self))
+ 
+        def _repr(v, limit=80):
+            """Truncate long reprs so log lines stay readable."""
+            r = repr(v)
+            return r if len(r) <= limit else r[:limit] + "…"
+ 
+        arg_str = ", ".join(
+            [*(f"{_repr(a)}" for a in args),
+             *(f"{k}={_repr(v)}" for k, v in kwargs.items())]
+        )
+ 
+        t0 = time.perf_counter()
+        try:
+            result = method(self, *args, **kwargs)
+            elapsed = (time.perf_counter() - t0) * 1_000_000
+            logger.debug(
+                "[TSDD] %s | %s(%d) | id=%s | %s(%s) -> %s  [%.1f µs]",
+                time.strftime("%Y-%m-%d %H:%M:%S"),
+                thread.name, thread.ident,
+                id_str,
+                name, arg_str,
+                _repr(result),
+                elapsed,
+            )
+            return result
+        except Exception as exc:
+            elapsed = (time.perf_counter() - t0) * 1_000_000
+            logger.debug(
+                "[TSDD] %s | %s(%d) | id=%s | %s(%s) !! %s: %s  [%.1f µs]\n%s",
+                time.strftime("%Y-%m-%d %H:%M:%S"),
+                thread.name, thread.ident,
+                id_str,
+                name, arg_str,
+                type(exc).__name__, exc,
+                elapsed,
+                traceback.format_exc(),
+            )
+            raise
+ 
+    return wrapper
+ 
+# ---------------------------------------------------------------------------
+# Main class
+# ---------------------------------------------------------------------------
+
+class ThreadSafeDeviceDict(MutableMapping):
+    """A thread-safe, dict-like mapping whose values are also thread-safe.
+
+    Wraps an internal ``dict`` and protects every read and write with a
+    :class:`threading.RLock`.  Using an *reentrant* lock means the same
+    thread can call multiple methods in sequence (or nest a
+    ``with self.lock():`` block around several operations) without
+    deadlocking.
+
+    **Auto-wrapping of inner dicts**
+
+    Whenever a plain :class:`dict` is stored as a value – whether via
+    ``__setitem__``, ``update``, ``setdefault``, or the constructor – it is
+    silently converted to a :class:`ThreadSafeDeviceDict`.  This means
+    nested access such as::
+
+        device = self.ListOfDevices[nwkid]   # returns ThreadSafeDeviceDict
+        device["battery"] = 90               # protected by device's own lock
+
+    is safe without any extra locking by the caller.
+
+    **Compound operations**
+
+    Individual method calls are atomic, but check-then-act patterns are
+    not.  Use the :meth:`lock` context manager to make a block of
+    operations atomic::
+
+        with self.ListOfDevices.lock():
+            if nwkid not in self.ListOfDevices:
+                self.ListOfDevices[nwkid] = {"status": "new"}
+
+    **Multiple instances**
+
+    Every instance creates its own independent ``RLock``::
+
+        self.IEEE2NWK             = ThreadSafeDeviceDict()  # lock #1
+        self.ListOfDomoticzWidget = ThreadSafeDeviceDict()  # lock #2
+        self.ListOfDevices        = ThreadSafeDeviceDict()  # lock #3
+
+    Nesting locks from *different* instances in inconsistent orders across
+    threads will cause a deadlock.  Always acquire them in the same order.
+    
+    **Debug tracing**
+ 
+    Enable per-call trace logging globally::
+ 
+        import thread_safe_device_dict as tsdd
+        tsdd.TSDD_DEBUG = True              # module-level flag (takes effect immediately)
+ 
+        # or via the class helper:
+        ThreadSafeDeviceDict.set_debug(True)
+ 
+    Configure the standard logger to see the output::
+ 
+        import logging
+        logging.basicConfig(level=logging.DEBUG)
+ 
+    Each log line contains timestamp, thread name/id, instance id (hex),
+    method name with arguments, return value, and duration in microseconds.
+    Set the flag back to ``False`` at any time to silence tracing instantly.
+    """
+
+    @classmethod
+    def set_debug(cls, enabled: bool) -> None:
+        """Enable or disable debug tracing at runtime without a restart.
+ 
+        Flips the module-level ``TSDD_DEBUG`` flag so the change takes
+        effect on the very next method call across **all** instances.
+ 
+        Args:
+            enabled: ``True`` to turn tracing on, ``False`` to turn it off.
+ 
+        Example::
+ 
+            ThreadSafeDeviceDict.set_debug(True)
+            # … reproduce the bug …
+            ThreadSafeDeviceDict.set_debug(False)
+        """
+        global TSDD_DEBUG
+        TSDD_DEBUG = enabled
+        logger.info("[TSDD] debug tracing %s", "ENABLED" if enabled else "DISABLED")
+ 
+    @_tsdd_trace
+    def __init__(self, *args, **kwargs):
+        """Initialise the mapping, optionally from an existing dict or iterable.
+
+        Accepts the same arguments as the built-in :class:`dict` constructor.
+        All plain dict values are auto-wrapped during initialisation.
+
+        Examples::
+
+            d = ThreadSafeDeviceDict()
+            d = ThreadSafeDeviceDict({"abc": {"battery": 100}})
+            d = ThreadSafeDeviceDict(abc={"battery": 100})
+        """
+        self._lock = threading.RLock()
+        self._data = {}
+        # Route through update() so every value is wrapped via __setitem__.
+        self.update(dict(*args, **kwargs))
+
+    # ------------------------------------------------------------------
+    # Auto-wrap helper
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _wrap(value):
+        """Return *value* wrapped in a :class:`ThreadSafeDeviceDict` if needed.
+
+        Only plain :class:`dict` instances are wrapped; values that are
+        already a :class:`ThreadSafeDeviceDict` (or any other type) are
+        returned unchanged.  The wrapping is recursive: nested plain dicts
+        inside *value* are also wrapped by the :class:`ThreadSafeDeviceDict`
+        constructor.
+
+        Args:
+            value: The value to (potentially) wrap.
+
+        Returns:
+            A :class:`ThreadSafeDeviceDict` when *value* is a plain
+            :class:`dict`, otherwise *value* unmodified.
+        """
+        if isinstance(value, dict) and not isinstance(value, ThreadSafeDeviceDict):
+            return ThreadSafeDeviceDict(value)
+        return value
+
+    # ------------------------------------------------------------------
+    # Core MutableMapping interface
+    # ------------------------------------------------------------------
+
+    @_tsdd_trace
+    def __setitem__(self, key, value):
+        """Set ``self[key] = value``, auto-wrapping plain dict values.
+
+        Thread-safe.  If *value* is a plain :class:`dict` it is converted
+        to a :class:`ThreadSafeDeviceDict` before being stored.
+
+        Args:
+            key: Mapping key.
+            value: Value to store; plain dicts are auto-wrapped.
+        """
+        with self._lock:
+            self._data[key] = self._wrap(value)
+
+    @_tsdd_trace
+    def __getitem__(self, key):
+        """Return ``self[key]``.
+
+        Thread-safe.
+
+        Args:
+            key: Mapping key to look up.
+
+        Raises:
+            KeyError: If *key* is not present.
+        """
+        with self._lock:
+            return self._data[key]
+
+    @_tsdd_trace
+    def __delitem__(self, key):
+        """Delete ``self[key]``.
+
+        Thread-safe.
+
+        Args:
+            key: Mapping key to remove.
+
+        Raises:
+            KeyError: If *key* is not present.
+        """
+        with self._lock:
+            del self._data[key]
+
+    def __iter__(self):
+        """Return an iterator over a *snapshot* of the current keys.
+
+        A snapshot (list copy) is taken under the lock so that another
+        thread modifying the mapping while the caller iterates does not
+        raise :exc:`RuntimeError`.
+
+        Returns:
+            An iterator over the keys present at the moment of the call.
+        """
+        with self._lock:
+            return iter(list(self._data))
+
+    def __len__(self):
+        """Return the number of items in the mapping.
+
+        Thread-safe.
+
+        Returns:
+            Integer number of stored keys.
+        """
+        with self._lock:
+            return len(self._data)
+
+    def __contains__(self, key):
+        """Return ``True`` if *key* is present in the mapping.
+
+        Thread-safe.
+
+        Args:
+            key: Key to test for membership.
+
+        Returns:
+            ``True`` if present, ``False`` otherwise.
+        """
+        with self._lock:
+            return key in self._data
+
+    def __repr__(self):
+        """Return a developer-friendly string representation.
+
+        Thread-safe.
+
+        Returns:
+            A string of the form ``ThreadSafeDeviceDict({...})``.
+        """
+        with self._lock:
+            return f"{self.__class__.__name__}({self._data!r})"
+
+    # ------------------------------------------------------------------
+    # Convenience / safety extras
+    # ------------------------------------------------------------------
+
+    @_tsdd_trace
+    def get(self, key, default=None):
+        """Return the value for *key*, or *default* if absent.
+
+        Thread-safe.
+
+        Args:
+            key: Key to look up.
+            default: Value returned when *key* is missing (default ``None``).
+
+        Returns:
+            The stored value or *default*.
+        """
+        with self._lock:
+            return self._data.get(key, default)
+
+    @_tsdd_trace
+    def setdefault(self, key, default=None):
+        """Return ``self[key]``, inserting *default* (auto-wrapped) if absent.
+
+        The check and the optional insertion are performed atomically under
+        the lock, so no other thread can insert the same key between the
+        test and the write.
+
+        Args:
+            key: Key to look up or insert.
+            default: Value to store when *key* is absent; plain dicts are
+                auto-wrapped (default ``None``).
+
+        Returns:
+            The existing or newly inserted value for *key*.
+        """
+        with self._lock:
+            if key not in self._data:
+                self._data[key] = self._wrap(default)
+            return self._data[key]
+
+    @_tsdd_trace
+    def pop(self, key, *args):
+        """Remove *key* and return its value, or *default* if absent.
+
+        Thread-safe.
+
+        Args:
+            key: Key to remove.
+            *args: Optional single default value.  If omitted and *key* is
+                missing a :exc:`KeyError` is raised (standard dict behaviour).
+
+        Returns:
+            The value that was stored under *key*, or the default.
+
+        Raises:
+            KeyError: If *key* is missing and no default was supplied.
+        """
+        with self._lock:
+            return self._data.pop(key, *args)
+
+    @_tsdd_trace
+    def update(self, other=None, **kwargs):
+        """Update the mapping from *other* and/or keyword arguments.
+
+        All plain dict values are auto-wrapped.  The merge of *other* and
+        *kwargs* is performed atomically under the lock.
+
+        Args:
+            other: A mapping or iterable of key/value pairs (optional).
+            **kwargs: Additional key/value pairs.
+        """
+        with self._lock:
+            merged = {}
+            if other is not None:
+                merged.update(other)
+            merged.update(kwargs)
+            for k, v in merged.items():
+                self._data[k] = self._wrap(v)
+
+    @_tsdd_trace
+    def keys(self):
+        """Return a snapshot list of all keys.
+
+        Thread-safe.  Returns a ``list`` rather than a view so that the
+        result is stable even if the mapping is modified afterwards.
+
+        Returns:
+            A ``list`` of keys.
+        """
+        with self._lock:
+            return list(self._data.keys())
+
+    @_tsdd_trace
+    def values(self):
+        """Return a snapshot list of all values.
+
+        Thread-safe.  Returns a ``list`` rather than a view so that the
+        result is stable even if the mapping is modified afterwards.
+
+        Returns:
+            A ``list`` of values.
+        """
+        with self._lock:
+            return list(self._data.values())
+
+    @_tsdd_trace
+    def items(self):
+        """Return a snapshot list of all ``(key, value)`` pairs.
+
+        Thread-safe.  Returns a ``list`` rather than a view so that the
+        result is stable even if the mapping is modified afterwards.
+
+        Returns:
+            A ``list`` of ``(key, value)`` tuples.
+        """
+        with self._lock:
+            return list(self._data.items())
+
+    @_tsdd_trace
+    def snapshot(self):
+        """Return a plain ``dict`` shallow copy of the current state.
+
+        Useful for serialisation, logging, or passing data to code that
+        expects a plain ``dict``.  The copy is taken atomically under the
+        lock, but subsequent changes to the mapping are not reflected.
+
+        Returns:
+            A plain :class:`dict` with the same keys and values as this
+            mapping at the moment of the call.
+        """
+        with self._lock:
+            return dict(self._data)
+
+    @contextmanager
+    def lock(self):
+        """Context manager that holds the internal ``RLock`` for the block.
+
+        Use this to make a sequence of operations atomic from the
+        perspective of other threads::
+
+            with self.ListOfDevices.lock():
+                if nwkid not in self.ListOfDevices:
+                    self.ListOfDevices[nwkid] = {"status": "new"}
+                self.ListOfDevices[nwkid]["battery"] = 100
+
+        Because the underlying lock is an ``RLock``, all normal method calls
+        inside the block re-enter the lock safely without deadlocking.
+
+        Yields:
+            Nothing; control passes to the ``with`` block body.
+        """
+        if TSDD_DEBUG:
+            thread = threading.current_thread()
+            t0 = time.perf_counter()
+            logger.debug(
+                "[TSDD] %s | %s(%d) | id=%s | lock() ENTER",
+                time.strftime("%Y-%m-%d %H:%M:%S"),
+                thread.name, thread.ident, hex(id(self)),
+            )
+        with self._lock:
+            yield
+        if TSDD_DEBUG:
+            elapsed = (time.perf_counter() - t0) * 1_000_000
+            logger.debug(
+                "[TSDD] %s | %s(%d) | id=%s | lock() EXIT  [%.1f µs]",
+                time.strftime("%Y-%m-%d %H:%M:%S"),
+                thread.name, thread.ident, hex(id(self)), elapsed,
+            )
+ 

--- a/plugin.py
+++ b/plugin.py
@@ -195,7 +195,7 @@ from Modules.zigateCommands import (zigate_erase_eeprom,
 from Modules.zigateConsts import CERTIFICATION, HEARTBEAT, MAX_FOR_ZIGATE_BUZY
 from Modules.zigpyBackup import handle_zigpy_backup
 from Zigbee.zdpCommands import zdp_get_permit_joint_status
-
+from Classes.ThreadSafeDeviceDict import ThreadSafeDeviceDict
 #import tracemalloc
 
 VERSION_FILENAME = ".hidden/VERSION"
@@ -223,16 +223,18 @@ class BasePlugin:
     def __init__(self):
 
         self.internet_available = None
-        self.ListOfDevices = (
-            {}
-        )  # {DevicesAddresse : { status : status_de_detection, data : {ep list ou autres en fonctions du status}}, DevicesAddresse : ...}
-        self.DiscoveryDevices = {}  # Used to collect pairing information
-        self.IEEE2NWK = {}
-        self.ControllerData = {}
+        
         self.DeviceConf = {}  # Store DeviceConf.txt, all known devices configuration
         self.ModelManufMapping = {}
         self.readZclClusters = {}
-        self.ListOfDomoticzWidget = {}
+        self.pluginconf = None  # PlugConf object / all configuration parameters
+
+        self.ListOfDomoticzWidget = ThreadSafeDeviceDict()
+        self.ListOfDevices = ThreadSafeDeviceDict()
+        self.IEEE2NWK = ThreadSafeDeviceDict()
+
+        self.DiscoveryDevices = {}  # Used to collect pairing information
+        self.ControllerData = {}
 
         # Objects from Classe
         self.configureReporting = None
@@ -247,7 +249,7 @@ class BasePlugin:
         self.domoticzdb_Hardware = None  # Object allowing direct access to Domoticz DB Hardware
         self.domoticzdb_Preferences = None  # Object allowing direct access to Domoticz DB Preferences
         self.adminWidgets = None  # Manage AdminWidgets object
-        self.pluginconf = None  # PlugConf object / all configuration parameters
+        
         self.OTA = None
         self.statistics = None
         self.iaszonemgt = None  # Object to manage IAS Zone

--- a/tests/test_ThreadSafeDeviceDict.py
+++ b/tests/test_ThreadSafeDeviceDict.py
@@ -1,0 +1,400 @@
+"""
+test_thread_safe_device_dict.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Unit and concurrency tests for ThreadSafeDeviceDict.
+
+Run with:
+    python -m pytest test_thread_safe_device_dict.py -v
+"""
+
+import threading
+import time
+import unittest
+
+from Classes.ThreadSafeDeviceDict import ThreadSafeDeviceDict
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_device():
+    """Return a typical zigbee device sub-dict."""
+    return {"battery": 100, "status": "active", "ep": {"01": {"cluster": "0006"}}}
+
+
+# ---------------------------------------------------------------------------
+# 1. Construction
+# ---------------------------------------------------------------------------
+
+class TestConstruction(unittest.TestCase):
+
+    def test_empty_construction(self):
+        d = ThreadSafeDeviceDict()
+        self.assertEqual(len(d), 0)
+
+    def test_construction_from_dict(self):
+        d = ThreadSafeDeviceDict({"abc": {"battery": 90}})
+        self.assertIn("abc", d)
+        self.assertEqual(d["abc"]["battery"], 90)
+
+    def test_construction_from_kwargs(self):
+        d = ThreadSafeDeviceDict(key1="val1", key2="val2")
+        self.assertEqual(d["key1"], "val1")
+
+    def test_inner_dict_wrapped_at_construction(self):
+        d = ThreadSafeDeviceDict({"abc": {"battery": 90}})
+        self.assertIsInstance(d["abc"], ThreadSafeDeviceDict)
+
+    def test_deeply_nested_dict_wrapped_at_construction(self):
+        d = ThreadSafeDeviceDict({"abc": {"ep": {"01": {"cluster": "0006"}}}})
+        self.assertIsInstance(d["abc"], ThreadSafeDeviceDict)
+        self.assertIsInstance(d["abc"]["ep"], ThreadSafeDeviceDict)
+        self.assertIsInstance(d["abc"]["ep"]["01"], ThreadSafeDeviceDict)
+
+
+# ---------------------------------------------------------------------------
+# 2. Basic dict operations
+# ---------------------------------------------------------------------------
+
+class TestBasicOperations(unittest.TestCase):
+
+    def setUp(self):
+        self.d = ThreadSafeDeviceDict()
+
+    def test_setitem_and_getitem(self):
+        self.d["abc"] = {"battery": 80}
+        self.assertEqual(self.d["abc"]["battery"], 80)
+
+    def test_delitem(self):
+        self.d["abc"] = {}
+        del self.d["abc"]
+        self.assertNotIn("abc", self.d)
+
+    def test_delitem_missing_raises(self):
+        with self.assertRaises(KeyError):
+            del self.d["missing"]
+
+    def test_getitem_missing_raises(self):
+        with self.assertRaises(KeyError):
+            _ = self.d["missing"]
+
+    def test_contains(self):
+        self.d["abc"] = {}
+        self.assertIn("abc", self.d)
+        self.assertNotIn("xyz", self.d)
+
+    def test_len(self):
+        self.assertEqual(len(self.d), 0)
+        self.d["a"] = 1
+        self.d["b"] = 2
+        self.assertEqual(len(self.d), 2)
+
+    def test_iter(self):
+        self.d["a"] = 1
+        self.d["b"] = 2
+        self.assertEqual(set(self.d), {"a", "b"})
+
+    def test_repr(self):
+        r = repr(self.d)
+        self.assertTrue(r.startswith("ThreadSafeDeviceDict("))
+
+    def test_keys(self):
+        self.d["a"] = 1
+        self.assertIn("a", self.d.keys())
+
+    def test_values(self):
+        self.d["a"] = 42
+        self.assertIn(42, self.d.values())
+
+    def test_items(self):
+        self.d["a"] = 1
+        self.assertIn(("a", 1), self.d.items())
+
+
+# ---------------------------------------------------------------------------
+# 3. Auto-wrapping
+# ---------------------------------------------------------------------------
+
+class TestAutoWrapping(unittest.TestCase):
+
+    def test_plain_dict_wrapped_on_setitem(self):
+        d = ThreadSafeDeviceDict()
+        d["abc"] = {"battery": 90}
+        self.assertIsInstance(d["abc"], ThreadSafeDeviceDict)
+
+    def test_already_wrapped_not_double_wrapped(self):
+        d = ThreadSafeDeviceDict()
+        inner = ThreadSafeDeviceDict({"battery": 90})
+        d["abc"] = inner
+        self.assertIs(d["abc"], inner)
+
+    def test_non_dict_not_wrapped(self):
+        d = ThreadSafeDeviceDict()
+        d["key"] = 42
+        self.assertIsInstance(d["key"], int)
+
+    def test_nested_write_is_protected(self):
+        d = ThreadSafeDeviceDict()
+        d["abc"] = {"battery": 100}
+        d["abc"]["battery"] = 50        # must not raise
+        self.assertEqual(d["abc"]["battery"], 50)
+
+    def test_update_wraps_values(self):
+        d = ThreadSafeDeviceDict()
+        d.update({"abc": {"battery": 70}})
+        self.assertIsInstance(d["abc"], ThreadSafeDeviceDict)
+
+
+# ---------------------------------------------------------------------------
+# 4. Convenience methods
+# ---------------------------------------------------------------------------
+
+class TestConvenienceMethods(unittest.TestCase):
+
+    def setUp(self):
+        self.d = ThreadSafeDeviceDict({"abc": {"battery": 100}})
+
+    def test_get_existing(self):
+        self.assertEqual(self.d.get("abc")["battery"], 100)
+
+    def test_get_missing_returns_default(self):
+        self.assertIsNone(self.d.get("missing"))
+        self.assertEqual(self.d.get("missing", "fallback"), "fallback")
+
+    def test_setdefault_existing_unchanged(self):
+        original = self.d["abc"]
+        result = self.d.setdefault("abc", {"battery": 0})
+        self.assertIs(result, original)
+
+    def test_setdefault_missing_inserts(self):
+        result = self.d.setdefault("new_nwkid", {"battery": 50})
+        self.assertIsInstance(result, ThreadSafeDeviceDict)
+        self.assertEqual(result["battery"], 50)
+        self.assertIn("new_nwkid", self.d)
+
+    def test_setdefault_wraps_default(self):
+        self.d.setdefault("x", {"battery": 10})
+        self.assertIsInstance(self.d["x"], ThreadSafeDeviceDict)
+
+    def test_pop_existing(self):
+        val = self.d.pop("abc")
+        self.assertNotIn("abc", self.d)
+        self.assertEqual(val["battery"], 100)
+
+    def test_pop_missing_with_default(self):
+        self.assertEqual(self.d.pop("missing", "default"), "default")
+
+    def test_pop_missing_no_default_raises(self):
+        with self.assertRaises(KeyError):
+            self.d.pop("missing")
+
+    def test_snapshot_returns_plain_dict(self):
+        snap = self.d.snapshot()
+        self.assertIsInstance(snap, dict)
+        self.assertNotIsInstance(snap, ThreadSafeDeviceDict)
+        self.assertIn("abc", snap)
+
+    def test_snapshot_is_independent(self):
+        snap = self.d.snapshot()
+        self.d["abc"]["battery"] = 0
+        # snapshot still holds the ThreadSafeDeviceDict reference, but is a
+        # separate top-level dict
+        self.assertIn("abc", snap)
+
+
+# ---------------------------------------------------------------------------
+# 5. lock() context manager
+# ---------------------------------------------------------------------------
+
+class TestLockContextManager(unittest.TestCase):
+
+    def test_lock_allows_compound_operation(self):
+        d = ThreadSafeDeviceDict()
+        with d.lock():
+            if "abc" not in d:
+                d["abc"] = {"status": "new"}
+            d["abc"]["battery"] = 99
+        self.assertEqual(d["abc"]["battery"], 99)
+
+    def test_lock_is_reentrant(self):
+        """Calling methods inside lock() must not deadlock."""
+        d = ThreadSafeDeviceDict({"abc": {}})
+        with d.lock():
+            d["abc"]["battery"] = 42    # re-enters _lock on inner dict
+            _ = d["abc"]["battery"]     # re-enters outer _lock via __getitem__
+        self.assertEqual(d["abc"]["battery"], 42)
+
+    def test_each_instance_has_independent_lock(self):
+        d1 = ThreadSafeDeviceDict()
+        d2 = ThreadSafeDeviceDict()
+        self.assertIsNot(d1._lock, d2._lock)
+
+
+# ---------------------------------------------------------------------------
+# 6. Thread-safety (concurrency stress tests)
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety(unittest.TestCase):
+
+    def test_concurrent_writes_no_data_loss(self):
+        """100 threads each writing a unique key → all 100 keys present."""
+        d = ThreadSafeDeviceDict()
+        num_threads = 100
+
+        def writer(i):
+            d[f"device_{i}"] = {"battery": i}
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(len(d), num_threads)
+
+    def test_concurrent_nested_writes(self):
+        """Multiple threads updating nested keys on the same device."""
+        d = ThreadSafeDeviceDict()
+        d["abc"] = {"battery": 0, "counter": 0}
+        iterations = 1000
+
+        def increment():
+            for _ in range(iterations):
+                with d.lock():
+                    current = d["abc"]["counter"]
+                    d["abc"]["counter"] = current + 1
+
+        threads = [threading.Thread(target=increment) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(d["abc"]["counter"], 5 * iterations)
+
+    def test_concurrent_reads_and_writes(self):
+        """Readers and writers run simultaneously without raising exceptions."""
+        d = ThreadSafeDeviceDict({"abc": {"battery": 100}})
+        errors = []
+
+        def reader():
+            for _ in range(500):
+                try:
+                    _ = d.get("abc", {})
+                    _ = d.items()
+                except Exception as e:
+                    errors.append(e)
+
+        def writer():
+            for i in range(500):
+                try:
+                    d["abc"] = {"battery": i % 101}
+                except Exception as e:
+                    errors.append(e)
+
+        threads = (
+            [threading.Thread(target=reader) for _ in range(4)]
+            + [threading.Thread(target=writer) for _ in range(2)]
+        )
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [], f"Exceptions raised: {errors}")
+
+    def test_iteration_snapshot_safe_during_mutation(self):
+        """Iterating while another thread adds keys must not raise RuntimeError."""
+        d = ThreadSafeDeviceDict({str(i): {} for i in range(50)})
+        errors = []
+
+        def mutator():
+            for i in range(50, 100):
+                d[str(i)] = {}
+                time.sleep(0)
+
+        def iterator():
+            try:
+                for _ in d:
+                    time.sleep(0)
+            except RuntimeError as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=mutator)
+        t2 = threading.Thread(target=iterator)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        self.assertEqual(errors, [], "RuntimeError raised during concurrent iteration")
+
+    def test_setdefault_no_double_insertion(self):
+        """Only one thread should win the setdefault race."""
+        d = ThreadSafeDeviceDict()
+        results = []
+
+        def inserter():
+            val = d.setdefault("shared_key", {"inserted_by": threading.get_ident()})
+            results.append(val["inserted_by"])
+
+        threads = [threading.Thread(target=inserter) for _ in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All threads must see the same winner
+        self.assertEqual(len(set(results)), 1, "setdefault returned different objects")
+        self.assertEqual(len(d), 1)
+
+
+# ---------------------------------------------------------------------------
+# 7. Zigbee-specific usage patterns
+# ---------------------------------------------------------------------------
+
+class TestZigbeePatterns(unittest.TestCase):
+    """Realistic patterns as used in zigbeefordomoticz."""
+
+    def test_list_of_devices_typical_workflow(self):
+        ListOfDevices = ThreadSafeDeviceDict()
+
+        nwkid = "1234"
+        ListOfDevices[nwkid] = make_device()
+        ListOfDevices[nwkid]["battery"] = 85
+        ListOfDevices[nwkid]["ep"]["01"]["cluster"] = "0008"
+
+        self.assertEqual(ListOfDevices[nwkid]["battery"], 85)
+        self.assertEqual(ListOfDevices[nwkid]["ep"]["01"]["cluster"], "0008")
+
+    def test_ieee2nwk_lookup(self):
+        IEEE2NWK = ThreadSafeDeviceDict()
+        IEEE2NWK["00:11:22:33:44:55:66:77"] = "1234"
+        self.assertEqual(IEEE2NWK["00:11:22:33:44:55:66:77"], "1234")
+
+    def test_multiple_independent_dicts(self):
+        IEEE2NWK             = ThreadSafeDeviceDict()
+        ListOfDomoticzWidget = ThreadSafeDeviceDict()
+        ListOfDevices        = ThreadSafeDeviceDict()
+
+        # Each has its own lock
+        self.assertIsNot(IEEE2NWK._lock, ListOfDomoticzWidget._lock)
+        self.assertIsNot(IEEE2NWK._lock, ListOfDevices._lock)
+        self.assertIsNot(ListOfDomoticzWidget._lock, ListOfDevices._lock)
+
+    def test_compound_check_and_create(self):
+        """Simulate safe initialisation of a new device entry."""
+        ListOfDevices = ThreadSafeDeviceDict()
+        nwkid = "abcd"
+
+        with ListOfDevices.lock():
+            if nwkid not in ListOfDevices:
+                ListOfDevices[nwkid] = {"status": "new", "battery": 255}
+
+        self.assertIn(nwkid, ListOfDevices)
+        self.assertEqual(ListOfDevices[nwkid]["status"], "new")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Replaces plain `dict` usage for the core plugin mappings with a new
`ThreadSafeDeviceDict` class that protects every read and write with a
reentrant lock (`threading.RLock`).  Inner dicts are auto-wrapped on
assignment, so existing two-level access patterns such as
`self.ListOfDevices[nwkid]["battery"] = 90` are protected transparently
without any changes to call sites.  A zero-overhead debug-trace decorator
is included for diagnosing concurrency issues in production.

---

## Motivation

`ListOfDevices`, `IEEE2NWK`, and `ListOfDomoticzWidget` are accessed from
multiple threads concurrently (the Domoticz framework thread, the zigbee
receive thread, and periodic housekeeping tasks).  Plain `dict` objects are
not thread-safe in CPython under all conditions: compound operations such as
check-then-insert and nested key writes are vulnerable to race conditions
that can produce silent data corruption, `KeyError`, or `RuntimeError`
during iteration.

---

## Files changed

| File | Lines | Description |
|---|---|---|
| `thread_safe_device_dict.py` | 536 | New class + debug decorator |
| `test_thread_safe_device_dict.py` | 574 | Full test suite (53 tests, all passing) |

---

## Design decisions

**`MutableMapping` base, not `dict` subclass**
Subclassing `dict` directly is unsafe because CPython's internal C-level
dict calls bypass Python-level overrides.  Wrapping a plain `dict` as
`self._data` gives full, reliable control over every access path.

**`RLock` (reentrant) instead of `Lock`**
The same thread may call multiple methods in sequence, or wrap a block in
`with self.lock():` while internal methods also acquire the lock.  An
`RLock` permits this without deadlocking by counting re-entrant acquisitions
from the same thread.

**Auto-wrapping of inner dicts**
Any plain `dict` stored as a value is silently converted to a
`ThreadSafeDeviceDict` before being saved.  This makes nested writes like
`device["battery"] = 90` safe without requiring callers to change their code.
The conversion is recursive, so deeply nested structures (e.g. endpoint maps)
are also protected.

**Snapshot returns in `__iter__`, `keys()`, `values()`, `items()`**
A list copy is taken under the lock so that a thread iterating the mapping
does not raise `RuntimeError` if another thread modifies it mid-loop.

**Independent lock per instance**
Each instance (`ListOfDevices`, `IEEE2NWK`, `ListOfDomoticzWidget`) owns its
own `RLock`.  They are completely independent.  The only deadlock risk arises
if two different instance locks are nested in opposite orders across threads —
always acquire them in a consistent order.

---

## API

### Drop-in replacement

```python
# Before
self.ListOfDevices        = {}
self.IEEE2NWK             = {}
self.ListOfDomoticzWidget = {}

# After — all existing code works unchanged
self.ListOfDevices        = ThreadSafeDeviceDict()
self.IEEE2NWK             = ThreadSafeDeviceDict()
self.ListOfDomoticzWidget = ThreadSafeDeviceDict()
```

### Compound operations (check-then-act)

Individual method calls are atomic, but multi-step patterns require the
`lock()` context manager:

```python
with self.ListOfDevices.lock():
    if nwkid not in self.ListOfDevices:
        self.ListOfDevices[nwkid] = {"Status": "new"}
    self.ListOfDevices[nwkid]["battery"] = 100
```

### `snapshot()` — point-in-time plain dict copy

```python
# Safe for serialisation or passing to code expecting a plain dict
copy = self.ListOfDevices.snapshot()
```

---

## Debug tracing

A `@_tsdd_trace` decorator is applied to all 19 methods.  When the
`TSDD_DEBUG` flag is `False` (the default) the decorator performs a single
boolean read and delegates immediately — no string formatting, no logging,
negligible overhead.

Enable at runtime without a restart:

```python
import thread_safe_device_dict as tsdd
tsdd.TSDD_DEBUG = True
# or:
ThreadSafeDeviceDict.set_debug(True)
```

Wire up standard Python logging to see output:

```python
import logging
logging.basicConfig(level=logging.DEBUG)
```

Each log line contains:

```
[TSDD] 2024-01-15 12:00:01 | Thread-3(140234) | id=0x7f3a | __setitem__('1234', {'battery': 90}) -> None  [38.4 µs]
```

The `lock()` context manager logs `ENTER` and `EXIT` events with elapsed
time so compound operations are visible in the trace:

```
[TSDD] 2024-01-15 12:00:01 | Thread-3(140234) | id=0x7f3a | lock() ENTER
[TSDD] 2024-01-15 12:00:01 | Thread-3(140234) | id=0x7f3a | lock() EXIT  [124.7 µs]
```

---

## Test coverage

53 tests across 8 suites, all passing (`python -m pytest -v`).

| Suite | Tests | What is covered |
|---|---|---|
| `TestConstruction` | 5 | Empty, from dict, kwargs, deep nesting at init |
| `TestBasicOperations` | 11 | All `MutableMapping` methods, error paths |
| `TestAutoWrapping` | 5 | Wrapping, no double-wrap, non-dict passthrough |
| `TestConvenienceMethods` | 10 | `get`, `setdefault`, `pop`, `snapshot` |
| `TestLockContextManager` | 3 | Compound ops, RLock re-entrancy, independent locks |
| `TestThreadSafety` | 5 | 100-thread write storm, nested counter, reader/writer mix, safe iteration, `setdefault` race |
| `TestZigbeePatterns` | 4 | Real patterns: `ListOfDevices`, `IEEE2NWK`, compound init |
| `TestDebugTracing` | 10 | Flag on/off, `set_debug()`, log content, exceptions, `lock()` ENTER/EXIT, distinct instance ids |
