### PR TITLE
prevent sending Simple Descriptor on none supported Ep

### DIFF
--- a/Modules/pairingProcess.py
+++ b/Modules/pairingProcess.py
@@ -246,33 +246,61 @@ def interview_state_8045(self, NWKID, RIA=None, status=None):
 
 
 def request_next_Ep(self, Nwkid):
-    if "ReqEpv2" not in self.ListOfDevices[Nwkid]:
-        self.ListOfDevices[Nwkid]["ReqEpv2"] = {}
-        
-    for iterEp in list(self.ListOfDevices[Nwkid]["Ep"]):
-        if is_fake_ep(self, Nwkid, iterEp):
+    if Nwkid not in self.ListOfDevices:
+        return True
+
+    device = self.ListOfDevices[Nwkid]
+    device.setdefault("ReqEpv2", {})
+
+    device_model = device.get("Model", "")
+    ep_dict = device.get("Ep", {})
+    epv2_dict = device.get("Epv2", {})
+    req_epv2 = device["ReqEpv2"]
+    now = time.time()
+
+    # if Config file exist, check the official list of EPs for this model, 
+    # and if we have some EPs which are not in the official list, let's skip them
+    if device_model not in ( {}, "") and device_model in self.DeviceConf and "Ep" in self.DeviceConf[device_model]:
+        official_eps = self.DeviceConf[device_model]["Ep"].keys()
+
+    # Blacklisted endpoints from device config (e.g. DeviceConf entry)
+    # 
+    blacklisted_eps = get_deviceconf_parameter_value(self, device_model, "BlackListEP")
+
+    SKIP_EPS = {"f2"}  # Green Power endpoint, always skipped
+
+    for ep in list(ep_dict):
+
+        if is_fake_ep(self, Nwkid, ep):
             continue
 
-        # Skip Green Zigbee EndPoint
-        if iterEp == 'f2':
-            continue
-        
-        if iterEp in self.ListOfDevices[Nwkid]["Epv2"] and self.ListOfDevices[Nwkid]["Ep"][ iterEp ] not in ( "", {}):
-            continue
-        
-        if iterEp in self.ListOfDevices[Nwkid]["ReqEpv2"] and self.ListOfDevices[Nwkid]["ReqEpv2"][ iterEp ] < ( time.time() + 120 ):
+        if ep not in official_eps:
+            self.log.logging("Pairing", "Debug", "[-] NEW OBJECT: %s Ep %s skipped (Not in official list of EP for this model)" % (Nwkid, ep))
             continue
 
-        # Let's request only 1 Ep, in order wait for the response and then request the next one
-        self.log.logging("Pairing", "Status", "[%s] NEW OBJECT: %s Request Simple Descriptor for Ep: %s" % ("-", Nwkid, iterEp))
-        self.ListOfDevices[Nwkid]["ReqEpv2"][ iterEp ] = time.time()
-        zdp_simple_descriptor_request(self, Nwkid, iterEp)
+        if ep in SKIP_EPS:
+            self.log.logging("Pairing", "Debug", "[-] NEW OBJECT: %s Ep %s skipped (SKIP_EP)" % (Nwkid, ep))
+            continue
+
+        if ep in blacklisted_eps:
+            self.log.logging("Pairing", "Debug", "[-] NEW OBJECT: %s Ep %s skipped (BlackListEP)" % (Nwkid, ep))
+            continue
+
+        # Already have a valid descriptor
+        if ep in epv2_dict and ep_dict[ep] not in ("", {}):
+            continue
+
+        # Requested recently — wait before retrying
+        if req_epv2.get(ep, 0) > now - 120:
+            continue
+
+        # Issue the request for this one endpoint and wait for the response
+        self.log.logging("Pairing", "Status", "[-] NEW OBJECT: %s Request Simple Descriptor for Ep: %s" % (Nwkid, ep))
+        req_epv2[ep] = now
+        zdp_simple_descriptor_request(self, Nwkid, ep)
         return False
-        
-    # We have been all Ep, and so nothing else to do
 
-    return True
-
+    return True  # All endpoints processed
    
 def interview_timeout(self, Devices, NWKID, RIA, status):
     self.log.logging( "Pairing", "Debug", "interview_timeout - NWKID: %s, Status: %s, RIA: %s," % ( NWKID, status, RIA, ), )


### PR DESCRIPTION
Fix #1945

# Pull Request Template — Zigbee4Domoticz (Domoticz-Zigbee)

Thank you for contributing! All PRs **must comply with the AGENTS.md guidance**:
https://github.com/zigbeefordomoticz/Domoticz-Zigbee/blob/stable8/AGENTS.md

---

## 📝 PR Type

- [x] Bug Fix
- [ ] Stability Improvement
- [ ] Device Support
- [ ] Documentation / Wiki Update
- [ ] Other (specify below)

---

## 🔖 Target Branch

**Production branch:** `stable8`  
- [x] This PR targets `stable8`
- [x] This PR targets a development/testing branch

> ⚠️ Only bug fixes or backward-compatible enhancements are allowed on `stable8`.

---

## ✅ Checklist Before Submitting

**Environment**
- [x] Python ≥ 3.11
- [x] Domoticz ≥ 2025.2

**Code Guidelines**
- [ ] `plugin.py` remains thin (orchestration only)
- [ ] Core logic is in `Modules/` or `Zigbee/`
- [ ] No UI changes (UI lives in separate repo)
- [ ] No breaking persistent data changes
- [ ] Async / threading patterns respected
- [ ] Logs are informative and not excessive

**Device Handling**
- [ ] Device behavior uses certified JSON (z4d-certified-devices)
- [ ] No hardcoding of devices
- [ ] Backward compatibility maintained

**Testing**
- [ ] All relevant tests pass
- [ ] Network, coordinator, and devices verified
- [ ] Changes tested on at least one real coordinator

---

## 🔧 Description of Changes

*(Provide a short, technical description of what is changed and why. Include references to any issues fixed.)*

---

## ⚠️ Known Limitations / Risks

*(List any potential backward-compatibility issues, network risks, or unstable behavior.)*

---

## 🧪 Testing Notes

- [ ] Describe steps to reproduce/test changes
- [ ] Include any special setup required (coordinator type, devices)

---

## 📌 Additional Notes for Reviewers / Agents

- All changes must be **conservative, safe, and backward-compatible**
- Changes impacting `Zigbee/` or async behavior must be **checked against all supported radios**
- Changes impacting `Modules/` must **not interfere with core Zigbee async flow**
- Human reviewers should check that **stable8 discipline** rules are followed

