### PR TITLE
Database Write Refactor 

### DIFF
--- a/Modules/database.py
+++ b/Modules/database.py
@@ -410,8 +410,11 @@ def is_domoticz_recent(self, dz_timestamp, device_list_txt_filename):
         return True
     return False
 
+def request_flush_plugin_listofdevices(self):
+    self.flush_list_of_devices = True
 
-def WriteDeviceList(self, count):  # sourcery skip: merge-nested-ifs
+
+def flush_plugin_listofdevice(self):  # sourcery skip: merge-nested-ifs
     """Persist the in-memory DeviceList to disk and Domoticz storage.
 
     Uses heartbeat counting to throttle writes. Will write both legacy text
@@ -421,16 +424,12 @@ def WriteDeviceList(self, count):  # sourcery skip: merge-nested-ifs
     Args:
         count: Number of heartbeats to wait between writes
     """
-    if self.HBcount < count:
-        self.HBcount = self.HBcount + 1
-        return
-
     if self.log:
-        self.log.logging("Database", "Debug", "WriteDeviceList %s %s" %(self.HBcount, count))
+        self.log.logging("Database", "Debug", "flush_plugin_listofdevice")
 
     if self.pluginconf.pluginConf["pluginData"] is None or self.DeviceListName is None:
         if self.log:
-            self.log.logging("Database", "Error", "WriteDeviceList - self.pluginconf.pluginConf['pluginData']: %s , self.DeviceListName: %s" % (
+            self.log.logging("Database", "Error", "flush_plugin_listofdevice - self.pluginconf.pluginConf['pluginData']: %s , self.DeviceListName: %s" % (
                 self.pluginconf.pluginConf["pluginData"], self.DeviceListName))
         return
 
@@ -443,15 +442,18 @@ def WriteDeviceList(self, count):  # sourcery skip: merge-nested-ifs
 
     use_domoticz_db = self.pluginconf.pluginConf.get("useDomoticzDb")
     store_in_domoticz_db = self.pluginconf.pluginConf.get("storeDomoticzDb")
-    self.log.logging("Database", "Debug", f"WriteDeviceList - useDomoticzDb: {use_domoticz_db} storeDomoticzDb: {store_in_domoticz_db}")
+    self.log.logging("Database", "Debug", f"flush_plugin_listofdevice - useDomoticzDb: {use_domoticz_db} storeDomoticzDb: {store_in_domoticz_db}")
 
     if ( Modules.tools.is_domoticz_db_available(self) and ( use_domoticz_db and store_in_domoticz_db)):
         if _write_DeviceList_Domoticz(self) is None:
             # An error occured. Probably Dz.Configuration() is not available.
-            self.log.logging("Database", "Error", "WriteDeviceList - flush Plugin db to Domoticz failed, we secure it to %s file" % self.DeviceListName)
+            self.log.logging("Database", "Error", "flush_plugin_listofdevice - flush Plugin db to Domoticz failed, we secure it to %s file" % self.DeviceListName)
             _write_DeviceList_txt(self)
 
     self.HBcount = 0
+    self.flush_list_of_devices = False
+
+
 def _write_DeviceList_txt(self):
     """Write device list in legacy text format.
 
@@ -496,17 +498,17 @@ def _write_DeviceList_txt(self):
                     continue
 
             # Make sure the bytes hit the disk before we swap the file in.
-            self.log.logging("Database", "Debug", "WriteDeviceList - flush Plugin db to %s" % _DeviceListFileName)
+            self.log.logging("Database", "Debug", "_write_DeviceList_txt - flush Plugin db to %s" % _DeviceListFileName)
             file.flush()
             os.fsync(file.fileno())
 
         # Atomic replace: the target is either the previous content or the
         # fully written new content, never a partial file.
         os.replace(_tmpFileName, _DeviceListFileName)
-        self.log.logging("Database", "Debug", "WriteDeviceList - flush Plugin db to %s" % _DeviceListFileName)
+        self.log.logging("Database", "Debug", "_write_DeviceList_txt - flush Plugin db to %s" % _DeviceListFileName)
 
     except FileNotFoundError:
-        self.log.logging( "Database", "Error", "WriteDeviceList - File not found >%s<" %_DeviceListFileName)
+        self.log.logging( "Database", "Error", "_write_DeviceList_txt - File not found >%s<" %_DeviceListFileName)
 
     except IOError:
         self.log.logging( "Database", "Error", "Error while Writing plugin Database %s" % _DeviceListFileName)
@@ -549,7 +551,7 @@ def _write_DeviceList_json(self):
                 os.remove(_tmpFileName)
         except OSError:
             pass
-    self.log.logging("Database", "Debug", "WriteDeviceList - flush Plugin db to %s" % _DeviceListFileName)
+    self.log.logging("Database", "Debug", "_write_DeviceList_json - flush Plugin db to %s" % _DeviceListFileName)
 
 
 def _write_DeviceList_Domoticz(self):

--- a/Modules/tools_device_lifecycle.py
+++ b/Modules/tools_device_lifecycle.py
@@ -8,7 +8,7 @@
 """Device lifecycle helpers extracted from tools.py"""
 import copy
 
-from Modules.database import PLUGIN_DATABASE_RECORD_VERSION, WriteDeviceList
+from Modules.database import PLUGIN_DATABASE_RECORD_VERSION, request_flush_plugin_listofdevices
 from Modules.domoticzAbstractLayer import domo_read_Device_Idx, domo_read_Name
 from Modules.pluginDbAttributes import STORE_CONFIGURE_REPORTING
 
@@ -114,7 +114,7 @@ def remap_device_nwkid(self, new_NwkId: str, IEEE: str, old_NwkId: str) -> bool:
             del self.ListOfDevices[new_NwkId][STORE_CONFIGURE_REPORTING]
         self.ListOfDevices[new_NwkId]["Heartbeat"] = "0"
 
-    WriteDeviceList(self, 0)
+    request_flush_plugin_listofdevices(self)
     self.log.logging("PluginTools", "Status", "NetworkID: %s is replacing %s for object: %s" % (new_NwkId, old_NwkId, IEEE))
     return True
 

--- a/plugin.py
+++ b/plugin.py
@@ -157,7 +157,7 @@ from Modules.checkingUpdate import (is_internet_available,
                                     start_version_check_worker,
                                     stop_version_check_worker)
 from Modules.command import domoticz_command
-from Modules.database import (LoadDeviceList, WriteDeviceList,
+from Modules.database import (LoadDeviceList, flush_plugin_listofdevice,
                               checkDevices2LOD, checkListOfDevice2Devices,
                               import_local_device_conf)
 from Modules.domoticzAbstractLayer import (
@@ -220,6 +220,7 @@ ZIGPY_BACKENDS = {
 }
 
 TRACE_MALLOC_MAX_DEPTH = 25
+DATABASE_FLUSH_PERIOD = 15 * 60  # 15 minutes
 
 class BasePlugin:
     enabled = False
@@ -289,7 +290,6 @@ class BasePlugin:
         self.Ping["Nb Ticks"] = self.Ping["Status"] = self.Ping["TimeStamp"] = None
         self.connectionState = None
 
-        self.HBcount = 0
         self.HeartbeatCount = 0
         self.internalHB = 0
 
@@ -314,6 +314,8 @@ class BasePlugin:
         self.PluzzyFirmware = False
         self.pluginVersion = {}
         self.z4d_certified_devices_version = None
+        
+        self.flush_list_of_devices = False
 
         self.loggingFileHandle = None
         self.level = 0
@@ -685,7 +687,7 @@ class BasePlugin:
         if self.log:
             self.log.logging(["Transport", "StopProcess"], "Log", "Flushing plugin database onto disk")
         if self.pluginconf:
-            WriteDeviceList(self, 0)  # write immediatly
+            flush_plugin_listofdevice(self)
 
         if self.domoticz_api:
             self.domoticz_api.stop()
@@ -713,7 +715,7 @@ class BasePlugin:
         if self.PDMready and self.pluginconf:
             if self.log:
                 self.log.logging(["Transport", "StopProcess"], "Log", "Flushing plugin database onto disk")
-            WriteDeviceList(self, 0)
+            flush_plugin_listofdevice(self)
 
         # Print and save statistics if configured
         if self.PDMready and self.pluginconf and self.statistics:
@@ -999,15 +1001,18 @@ class BasePlugin:
         if self.groupmgt:
             self.groupmgt.hearbeat_group_mgt()
 
-        # Write the ListOfDevice every 15 minutes or immediatly if we have remove or added a Device
-        if len(Devices) == prevLenDevices:
-            WriteDeviceList(self, ( (15 * 60) // HEARTBEAT) )
+        if self.flush_list_of_devices:
+            # If triggered / result of remap_device_nwkid()
+            _resync_device_registry(self)
 
-        else:
+        elif len(Devices) == prevLenDevices and ( DATABASE_FLUSH_PERIOD // HEARTBEAT) == self.internalHB:
+            # If no new devices, but the Period is over
+            flush_plugin_listofdevice(self)
+
+        elif len(Devices) != prevLenDevices:
+            # The List of Domoticz widget has changed!
             self.log.logging("Plugin", "Debug", "Devices size has changed , let's write ListOfDevices on disk")
-            WriteDeviceList(self, 0)  # write immediatly
-            networksize_update(self)
-            self.domoticz_device_cache.refresh()
+            _resync_device_registry(self)
   
         _trigger_coordinator_backup( self )
 
@@ -1050,6 +1055,12 @@ class BasePlugin:
     def onDeviceModified(self, DeviceId, Unit):
         device_idx = retrieve_widgetid_from_deviceId_unit(self, Devices, DeviceId, Unit)
         self.domoticz_device_cache.refresh_device( device_idx)
+
+
+def _resync_device_registry(self):
+    flush_plugin_listofdevice(self)
+    networksize_update(self)
+    self.domoticz_device_cache.refresh()
 
 
 def _plugin_statistics(self):


### PR DESCRIPTION
## Overview
This refactor reworks how the plugin persists its in-memory `ListOfDevices` to
disk and to the Domoticz database. The write throttling was moved out of the
database module and into the plugin heartbeat, an explicit "flush on demand"
mechanism was added, and serialization was hardened to handle `deque` objects
and newer record versions.

## 1. Write throttling moved out of the DB layer
- **Renamed** `WriteDeviceList(self, count)` → `flush_plugin_listofdevice(self)`.
- Removed the internal `HBcount < count` heartbeat-counting / throttling logic
  from the database module. The decision of *when* to flush now lives entirely
  in `plugin.py` (see §3).
- `self.HBcount` bookkeeping inside the writer is gone.

## 2. Explicit "flush on demand" mechanism
- New flag `self.flush_list_of_devices` (initialized to `False`).
- New helper `request_flush_plugin_listofdevices(self)` sets the flag so other
  code paths (e.g. `remap_device_nwkid()`) can request a flush.
- `flush_plugin_listofdevice()` resets the flag to `False` after writing.

## 3. Heartbeat-driven scheduling (plugin.py)
- New constant `DATABASE_FLUSH_PERIOD = 15 * 60` (15 minutes).
- Flush decision is now a three-way branch in the heartbeat:
  - `if self.flush_list_of_devices:` → resync device registry
  - `elif len(Devices) == prevLenDevices and ...period elapsed...` → periodic flush
  - `elif len(Devices) != prevLenDevices:` → immediate flush (widget count changed)
- Shutdown / explicit save paths now call `flush_plugin_listofdevice(self)`
  directly instead of `WriteDeviceList(self, 0)`.
