### PR TITLE
Prevent Ep = {} wipe entirely / `fix/lost-clustertype` — Protect provisioned `ClusterType` on Model-Name re-announcement

### DIFF
--- a/Modules/zclClusterHelpers.py
+++ b/Modules/zclClusterHelpers.py
@@ -367,7 +367,7 @@ def _has_non_empty_cluster_type(device_info):
     An endpoint with "ClusterType": {} or "" is treated as NOT provisioned.
     """
     return any(
-        ep_info.get("ClusterType") not in (None, "", {})
+        isinstance(ep_info, dict) and ep_info.get("ClusterType") not in (None, "", {})
         for ep_info in device_info.get("Ep", {}).values()
     )
 

--- a/Modules/zclClusterHelpers.py
+++ b/Modules/zclClusterHelpers.py
@@ -243,35 +243,30 @@ def _update_data_structutre_based_on_model_name( self, MsgSrcAddr, modelName):
     if "Type" in self.DeviceConf[modelName]:  # If type exist at top level : copy it
         self.ListOfDevices[MsgSrcAddr]["Type"] = self.DeviceConf[modelName]["Type"]
 
-        if "Ep" in self.ListOfDevices.get(MsgSrcAddr, {}):
-            self.log.logging([ "ZclClusters", "Pairing"], "Debug", "_handle_model_name should Removing existing received Ep", MsgSrcAddr)
+    # Non-destructive enrolment (issue #1987): we MUST keep any existing Ep data, in particular
+    # the per-endpoint "ClusterType" that cross-references the Domoticz widgets. A Model Name
+    # report can arrive at any time (rejoin, re-pair, battery check-in); wiping Ep here used to
+    # silently drop ClusterType and break widget updates. _upd_data_strut_based_on_model() is
+    # purely additive (it only creates missing endpoints/clusters), so we merge the DeviceConf
+    # skeleton on top of the existing Ep instead of resetting it.
+    self.ListOfDevices[MsgSrcAddr].setdefault("Ep", {})
+    self.log.logging([ "ZclClusters", "Pairing"], "Debug", "_handle_model_name merging DeviceConf into existing Ep (ClusterType preserved)", MsgSrcAddr)
+    before_cluster_type = _cluster_type_pairs(self.ListOfDevices[MsgSrcAddr])
 
-            if _has_non_empty_cluster_type(self.ListOfDevices.get(MsgSrcAddr, {})):
-                existing_ct = {
-                    ep: ep_info["ClusterType"]
-                    for ep, ep_info in self.ListOfDevices[MsgSrcAddr]["Ep"].items()
-                    if ep_info.get("ClusterType") not in (None, "", {})
-                }
-                self.log.logging(
-                    ["ZclClusters", "Pairing"], "Warning",
-                    f"_handle_model_name - {MsgSrcAddr} Model '{modelName}' "
-                    f"(ConfigSource={self.ListOfDevices[MsgSrcAddr].get('ConfigSource')}): "
-                    f"Ep reset BLOCKED to protect provisioned ClusterType {existing_ct}",
-                    MsgSrcAddr,
-                )
-            else:
-                self.log.logging(
-                    ["ZclClusters", "Pairing"], "Log",
-                    f"_handle_model_name - {MsgSrcAddr} Model '{modelName}': "
-                    f"resetting Ep (no provisioned ClusterType present)", MsgSrcAddr,
-                )
-                self.ListOfDevices[MsgSrcAddr]["Ep"] = {}
-                self.log.logging(
-                    ["ZclClusters", "Pairing"], "Debug",
-                    "-- Record after Ep reset: %s" % self.ListOfDevices[MsgSrcAddr], MsgSrcAddr,
-                )
+    result = _upd_data_strut_based_on_model(self, MsgSrcAddr, modelName, None)
 
-    _upd_data_strut_based_on_model(self, MsgSrcAddr, modelName, None)
+    # Invariant tripwire: re-enrolment must never drop a provisioned ClusterType entry. The only
+    # legitimate way to shrink ClusterType is removing a Domoticz widget. If this ever fires it
+    # means a new regression reintroduced a destructive Ep/ClusterType reset on this path.
+    lost_cluster_type = before_cluster_type - _cluster_type_pairs(self.ListOfDevices[MsgSrcAddr])
+    if lost_cluster_type:
+        self.log.logging(
+            ["ZclClusters", "Pairing"], "Error",
+            f"_handle_model_name - {MsgSrcAddr} Model '{modelName}': ClusterType shrank during "
+            f"re-enrollment (lost {sorted(lost_cluster_type)}) - this must never happen", MsgSrcAddr,
+        )
+
+    return result
 
 
 def _upd_data_strut_based_on_model(self, MsgSrcAddr, modelName, initial_ep):
@@ -338,6 +333,20 @@ def _build_model_name( self, nwkid, modelName):
         return plugin_identifier
 
     return check_found_plugin_model( self, modelName, manufacturer_name=manufacturer_name, manufacturer_code=manuf_code, device_id=zdevice_id)
+
+
+def _cluster_type_pairs(device_info):
+    """
+    Return the set of (endpoint, widget_idx) pairs currently registered across every
+    endpoint's 'ClusterType'. Used to assert that re-enrollment never drops a provisioned
+    widget cross-reference (issue #1987).
+    """
+    pairs = set()
+    for ep, ep_info in device_info.get("Ep", {}).items():
+        cluster_type = ep_info.get("ClusterType")
+        if isinstance(cluster_type, dict):
+            pairs.update((ep, widget_idx) for widget_idx in cluster_type)
+    return pairs
 
 
 def _has_non_empty_cluster_type(device_info):

--- a/Modules/zclClusterHelpers.py
+++ b/Modules/zclClusterHelpers.py
@@ -259,7 +259,7 @@ def _update_data_structutre_based_on_model_name( self, MsgSrcAddr, model_name):
             }
             self.log.logging(
                 ["ZclClusters", "Pairing"], "Warning",
-                f"Prevent datastructure update - {MsgSrcAddr} Model '{model_name}' "
+                f"Prevent datastructure refresh - {MsgSrcAddr} Model '{model_name}' "
                 f"(ConfigSource={self.ListOfDevices[MsgSrcAddr].get('ConfigSource')}): "
                 f"Ep reset BLOCKED to protect provisioned ClusterType {existing_ct}",
                 MsgSrcAddr,
@@ -268,7 +268,7 @@ def _update_data_structutre_based_on_model_name( self, MsgSrcAddr, model_name):
 
     self.log.logging(
         ["ZclClusters", "Pairing"], "Log",
-        f"Allowing datastructure update - {MsgSrcAddr} Model '{model_name}': "
+        f"Allowing datastructure refresh - {MsgSrcAddr} Model '{model_name}': "
         f"resetting Ep (no provisioned ClusterType present)", MsgSrcAddr,
     )
     self.ListOfDevices[MsgSrcAddr]["Ep"] = {}

--- a/Modules/zclClusterHelpers.py
+++ b/Modules/zclClusterHelpers.py
@@ -177,124 +177,148 @@ def decoding_attribute_data( attribute_type, attribute_value, handle_errors=Fals
 # Used by Cluster 0x0000
 
 def handle_model_name( self, MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAttrID, MsgAttType, MsgAttSize, device_model, rawvalue, value ):
-    self.log.logging( [ "ZclClusters", "Pairing"], "Debug", "_handle_model_name - %s / %s - %s %s %s %s %s - %s" % (
+    self.log.logging( [ "ZclClusters", "Pairing"], "Debug", "handle_model_name - %s / %s - %s %s %s %s %s - %s" % (
         MsgSrcAddr, MsgSrcEp, MsgClusterId, MsgAttrID, MsgAttType, MsgAttSize, value, device_model), MsgSrcAddr, )
     
-    modelName = _cleanup_model_name( MsgAttType, rawvalue)
-    self.log.logging( [ "ZclClusters", "Pairing"], "Debug", "_handle_model_name - modelName after cleanup %s" % modelName)
+    incoming_model_name = _cleanup_model_name( MsgAttType, rawvalue)
+    self.log.logging( [ "ZclClusters", "Pairing"], "Debug", "handle_model_name - incoming_model_name after cleanup %s" % incoming_model_name)
     
-    modelName = _build_model_name( self, MsgSrcAddr, modelName)
-    self.log.logging( [ "ZclClusters", "Pairing"], "Debug", "_handle_model_name - modelName after build model name %s" % modelName)
+    incoming_model_name = _build_model_name( self, MsgSrcAddr, incoming_model_name)
+    self.log.logging( [ "ZclClusters", "Pairing"], "Debug", "handle_model_name - incoming_model_name after build model name %s" % incoming_model_name)
     
     # Here the Device is not yet provisioned
     self.ListOfDevices[MsgSrcAddr].setdefault("Model", {})
 
-    self.log.logging( [ "ZclClusters", "Pairing"], "Debug", "_handle_model_name - %s / %s - Recepion Model: >%s<" % (
-        MsgClusterId, MsgAttrID, modelName), MsgSrcAddr, )
-    if modelName == "":
+    self.log.logging( [ "ZclClusters", "Pairing"], "Debug", "handle_model_name - %s / %s - Recepion Model: >%s<" % (
+        MsgClusterId, MsgAttrID, incoming_model_name), MsgSrcAddr, )
+    if incoming_model_name == "":
         return
 
-    if _provision_or_update_existing_device(self, MsgSrcAddr, modelName):
+    if _provision_or_update_existing_device(self, MsgSrcAddr, incoming_model_name):
+        # Device has been already provisionned. We update Model Name if needed
+        # but nothing else.
+        # If user when to benefit from the new Device conf, then it must remove widgets
+        # and redo pairing from scratch
         return
 
-    if self.ListOfDevices[MsgSrcAddr]["Model"] == modelName and self.ListOfDevices[MsgSrcAddr]["Model"] in self.DeviceConf:
+    # We have at that stage, a potential new device, where ClusterType is empy (no Domoticz widgets associated)
+    if self.ListOfDevices[MsgSrcAddr]["Model"] == incoming_model_name and self.ListOfDevices[MsgSrcAddr]["Model"] in self.DeviceConf:
         # This looks like a Duplicate, just drop
-        self.log.logging([ "ZclClusters", "Pairing"], "Debug", "_handle_model_name - %s / %s - no action" % (
+        self.log.logging([ "ZclClusters", "Pairing"], "Debug", "handle_model_name - %s / %s - no action" % (
             MsgClusterId, MsgAttrID), MsgSrcAddr)
         return
 
-    if self.ListOfDevices[MsgSrcAddr]["Model"] != modelName and self.ListOfDevices[MsgSrcAddr]["Model"] in self.DeviceConf:
-        # We ae getting a different Model Name, let's log an drop
-        self.log.logging( [ "ZclClusters", "Pairing"], "Error", "_handle_model_name - %s / %s - no action as it is a different Model Name than registered %s" % (
-            MsgClusterId, MsgAttrID, modelName), MsgSrcAddr, )
+    if self.ListOfDevices[MsgSrcAddr]["Model"] != incoming_model_name and self.ListOfDevices[MsgSrcAddr]["Model"] in self.DeviceConf:
+        # We are getting a different Model Name, let's log an drop
+        self.log.logging( [ "ZclClusters", "Pairing"], "Warning", "handle_model_name - %s / %s - no action as it is a different Model Name than registered %s" % (
+            MsgClusterId, MsgAttrID, incoming_model_name), MsgSrcAddr, )
         return
 
     if self.ListOfDevices[MsgSrcAddr]["Model"] in ( "", {}):
-        self.ListOfDevices[MsgSrcAddr]["Model"] = modelName
+        self.ListOfDevices[MsgSrcAddr]["Model"] = incoming_model_name
         
     elif self.ListOfDevices[MsgSrcAddr]["Model"] in self.DeviceConf:
-        modelName = self.ListOfDevices[MsgSrcAddr]["Model"]
+        # We overwrite the incoming model with the existing one !!!
+        incoming_model_name = self.ListOfDevices[MsgSrcAddr]["Model"]
         
-    elif modelName in self.DeviceConf:
-        self.ListOfDevices[MsgSrcAddr]["Model"] = modelName
+    elif incoming_model_name in self.DeviceConf:
+        self.ListOfDevices[MsgSrcAddr]["Model"] = incoming_model_name
 
-    if _update_data_structutre_based_on_model_name( self, MsgSrcAddr, modelName) and self.iaszonemgt:
+    if _update_data_structutre_based_on_model_name( self, MsgSrcAddr, incoming_model_name) and self.iaszonemgt:
         self.iaszonemgt.force_IAS_registration_if_needed(MsgSrcAddr)
 
 
-def _update_data_structutre_based_on_model_name( self, MsgSrcAddr, modelName):
+def _update_data_structutre_based_on_model_name( self, MsgSrcAddr, model_name):
     # Let's see if this model is known in DeviceConf. If so then we will retreive already the Eps
 
-    if self.ListOfDevices[MsgSrcAddr]["Model"] not in self.DeviceConf: 
+    if model_name not in self.DeviceConf: 
         return False
 
-    modelName = self.ListOfDevices[MsgSrcAddr]["Model"]
-    self.log.logging([ "ZclClusters", "Pairing"], "Debug", "_handle_model_name Extract all info from Model : %s" % self.DeviceConf[modelName], MsgSrcAddr)
+    self.log.logging([ "ZclClusters", "Pairing"], "Debug", "_update_data_structutre_based_on_model_name Extract all info from Model : %s" % self.DeviceConf[model_name], MsgSrcAddr)
 
     if _config_source_is_deviceconf(self, MsgSrcAddr):
-        self.log.logging([ "ZclClusters", "Pairing"], "Debug", "_handle_model_name Not redoing the DeviceConf enrollement", MsgSrcAddr)
+        self.log.logging([ "ZclClusters", "Pairing"], "Debug", "_update_data_structutre_based_on_model_name Not redoing the DeviceConf enrollement", MsgSrcAddr)
         return True
 
     self.ListOfDevices[MsgSrcAddr]["ConfigSource"] = "DeviceConf"
 
-    if "Param" in self.DeviceConf[modelName]:
-        self.ListOfDevices[MsgSrcAddr]["Param"] = dict(self.DeviceConf[modelName]["Param"])
+    if "Param" in self.DeviceConf[model_name]:
+        self.ListOfDevices[MsgSrcAddr]["Param"] = dict(self.DeviceConf[model_name]["Param"])
 
-    if "Type" in self.DeviceConf[modelName]:  # If type exist at top level : copy it
-        self.ListOfDevices[MsgSrcAddr]["Type"] = self.DeviceConf[modelName]["Type"]
+    if "Type" in self.DeviceConf[model_name]:  # If type exist at top level : copy it
+        self.ListOfDevices[MsgSrcAddr]["Type"] = self.DeviceConf[model_name]["Type"]
 
-    # Non-destructive enrolment (issue #1987): we MUST keep any existing Ep data, in particular
-    # the per-endpoint "ClusterType" that cross-references the Domoticz widgets. A Model Name
-    # report can arrive at any time (rejoin, re-pair, battery check-in); wiping Ep here used to
-    # silently drop ClusterType and break widget updates. _upd_data_strut_based_on_model() is
-    # purely additive (it only creates missing endpoints/clusters), so we merge the DeviceConf
-    # skeleton on top of the existing Ep instead of resetting it.
-    self.ListOfDevices[MsgSrcAddr].setdefault("Ep", {})
-    self.log.logging([ "ZclClusters", "Pairing"], "Debug", "_handle_model_name merging DeviceConf into existing Ep (ClusterType preserved)", MsgSrcAddr)
-    before_cluster_type = _cluster_type_pairs(self.ListOfDevices[MsgSrcAddr])
+    if "Ep" in self.ListOfDevices.get(MsgSrcAddr, {}):
+        self.log.logging([ "ZclClusters", "Pairing"], "Debug", "_update_data_structutre_based_on_model_name should Removing existing received Ep", MsgSrcAddr)
 
-    result = _upd_data_strut_based_on_model(self, MsgSrcAddr, modelName, None)
+        if _has_non_empty_cluster_type(self.ListOfDevices.get(MsgSrcAddr, {})):
+            existing_ct = {
+                ep: ep_info["ClusterType"]
+                for ep, ep_info in self.ListOfDevices[MsgSrcAddr]["Ep"].items()
+                if ep_info.get("ClusterType") not in (None, "", {})
+            }
+            self.log.logging(
+                ["ZclClusters", "Pairing"], "Warning",
+                f"Prevent datastructure update - {MsgSrcAddr} Model '{model_name}' "
+                f"(ConfigSource={self.ListOfDevices[MsgSrcAddr].get('ConfigSource')}): "
+                f"Ep reset BLOCKED to protect provisioned ClusterType {existing_ct}",
+                MsgSrcAddr,
+            )
+            return False
 
-    # Invariant tripwire: re-enrolment must never drop a provisioned ClusterType entry. The only
-    # legitimate way to shrink ClusterType is removing a Domoticz widget. If this ever fires it
-    # means a new regression reintroduced a destructive Ep/ClusterType reset on this path.
-    lost_cluster_type = before_cluster_type - _cluster_type_pairs(self.ListOfDevices[MsgSrcAddr])
-    if lost_cluster_type:
-        self.log.logging(
-            ["ZclClusters", "Pairing"], "Error",
-            f"_handle_model_name - {MsgSrcAddr} Model '{modelName}': ClusterType shrank during "
-            f"re-enrollment (lost {sorted(lost_cluster_type)}) - this must never happen", MsgSrcAddr,
-        )
+    self.log.logging(
+        ["ZclClusters", "Pairing"], "Log",
+        f"Allowing datastructure update - {MsgSrcAddr} Model '{model_name}': "
+        f"resetting Ep (no provisioned ClusterType present)", MsgSrcAddr,
+    )
+    self.ListOfDevices[MsgSrcAddr]["Ep"] = {}
+    self.log.logging(
+        ["ZclClusters", "Pairing"], "Debug",
+        "-- Record after Ep reset: %s" % self.ListOfDevices[MsgSrcAddr], MsgSrcAddr,
+    )
 
-    return result
+    return _upd_data_strut_based_on_model(self, MsgSrcAddr, model_name, None)
 
 
-def _upd_data_strut_based_on_model(self, MsgSrcAddr, modelName, initial_ep):
+def _upd_data_strut_based_on_model(self, MsgSrcAddr, model_name, initial_ep):
+    self.log.logging([ "ZclClusters", "Pairing"], "Log", f"-- _upd_data_strut_based_on_model {MsgSrcAddr} {model_name} {initial_ep}")
+
     device_info = self.ListOfDevices[MsgSrcAddr]
-    device_conf = self.DeviceConf[modelName]
+    device_conf = self.DeviceConf[model_name]
 
-    for ep, ep_info in device_conf.get("Ep", {}).items():
-        if ep not in device_info["Ep"]:
-            device_info["Ep"][ep] = {}
-            self.log.logging([ "ZclClusters", "Pairing"], "Debug", "-- Create Endpoint %s in record %s" % (ep, device_info["Ep"]), MsgSrcAddr)
+    for device_conf_ep, device_conf_ep_info in device_conf.get("Ep", {}).items():
+        
+        # 1_ Initialize ep based on device conf ep
+        if device_conf_ep not in device_info["Ep"]:
+            device_info["Ep"][device_conf_ep] = {}
+            self.log.logging([ "ZclClusters", "Pairing"], "Log", "-- Create Endpoint %s in record %s" % (device_conf_ep, device_info["Ep"]), MsgSrcAddr)
 
-        for cluster, cluster_info in ep_info.items():
-            if cluster not in device_info["Ep"][ep]:
-                device_info["Ep"][ep][cluster] = {}
+        # 2_ Populate Cluster
+        for cluster, cluster_info in device_conf_ep_info.items():
+            # Create Cluster
+            if cluster not in device_info["Ep"][device_conf_ep]:
+                device_info["Ep"][device_conf_ep][cluster] = {}
                 self.log.logging([ "ZclClusters", "Pairing"], "Debug", "----> Cluster: %s" % cluster, MsgSrcAddr)
 
-            if initial_ep and ep in initial_ep and cluster in initial_ep[ep]:
-                for attr, value in initial_ep[ep][cluster].items():
-                    if not device_info["Ep"][ep][cluster].get(attr) or device_info["Ep"][ep][cluster][attr] in ["", {}]:
-                        device_info["Ep"][ep][cluster][attr] = value
-                        self.log.logging([ "ZclClusters", "Pairing"], "Debug", "------> Cluster %s set with Attribute %s" % (cluster, attr), MsgSrcAddr)
+            # Create Attributes. As we might have the cluster already created during pairing
+            # and consequently might have already some attributes populated. Don't overwrite the attribute
+            if initial_ep and device_conf_ep in initial_ep and cluster in initial_ep[device_conf_ep]:
+                for attr, value in initial_ep[device_conf_ep][cluster].items():
+                    if device_info["Ep"][device_conf_ep][cluster].get(attr):
+                        continue
 
-        if "Type" in ep_info:
-            device_info["Ep"][ep]["Type"] = ep_info["Type"]
-        if "ColorMode" in ep_info:
+                    device_info["Ep"][device_conf_ep][cluster][attr] = value
+                    self.log.logging([ "ZclClusters", "Pairing"], "Debug", "------> Cluster %s set with Attribute %s" % (cluster, attr), MsgSrcAddr)
+
+        # 3_ Populate Ep/Type
+        if "Type" in device_conf_ep_info:
+            device_info["Ep"][device_conf_ep]["Type"] = device_conf_ep_info["Type"]
+
+        # 4_ Populate ColorMode
+        if "ColorMode" in device_conf_ep_info:
             if "ColorInfos" not in device_info:
                 device_info["ColorInfos"] = {}
-            device_info["ColorInfos"]["ColorMode"] = int(ep_info["ColorMode"])
+            device_info["ColorInfos"]["ColorMode"] = int(device_conf_ep_info["ColorMode"])
 
     self.log.logging([ "ZclClusters", "Pairing"], "Debug", "_handle_model_name Result based on DeviceConf is: %s" % str(device_info), MsgSrcAddr)
     return True
@@ -335,20 +359,6 @@ def _build_model_name( self, nwkid, modelName):
     return check_found_plugin_model( self, modelName, manufacturer_name=manufacturer_name, manufacturer_code=manuf_code, device_id=zdevice_id)
 
 
-def _cluster_type_pairs(device_info):
-    """
-    Return the set of (endpoint, widget_idx) pairs currently registered across every
-    endpoint's 'ClusterType'. Used to assert that re-enrollment never drops a provisioned
-    widget cross-reference (issue #1987).
-    """
-    pairs = set()
-    for ep, ep_info in device_info.get("Ep", {}).items():
-        cluster_type = ep_info.get("ClusterType")
-        if isinstance(cluster_type, dict):
-            pairs.update((ep, widget_idx) for widget_idx in cluster_type)
-    return pairs
-
-
 def _has_non_empty_cluster_type(device_info):
     """
     Returns True if at least one endpoint carries a non-empty 'ClusterType'
@@ -367,10 +377,13 @@ def _has_provisioned_endpoint(device_info):
     Pure check: returns True if any endpoint already carries a 'ClusterType'
     mapping (i.e. widgets have been provisioned for this device).
     """
-    return any("ClusterType" in ep_info for ep_info in device_info.get("Ep", {}).values())
+    return any(
+        isinstance(ep_info, dict) and ep_info.get("ClusterType")
+        for ep_info in device_info.get("Ep", {}).values()
+    )
 
 
-def _provision_or_update_existing_device(self, nwk_id, model_name):
+def _provision_or_update_existing_device(self, nwk_id, incoming_model_name):
     """
     If the device is already provisioned (at least one endpoint has a
     'ClusterType'), make sure its Model and configuration are up to date,
@@ -388,85 +401,30 @@ def _provision_or_update_existing_device(self, nwk_id, model_name):
     device_info = self.ListOfDevices.get(nwk_id, {})
 
     if not _has_provisioned_endpoint(device_info):
+        # Not Widgets on Domoticz, we have a new device
         return False
 
-    # Already provisioned. Nothing to do if the model is unchanged.
-    if device_info.get("Model") == model_name:
+    # Nothing to do if the model is unchanged.
+    if device_info.get("Model") == incoming_model_name:
         self.log.logging(
             ["ZclClusters", "Pairing"], "Debug",
-            f"{nwk_id} - {model_name} is already provisioned in Domoticz", nwk_id,
+            f"{nwk_id} - {incoming_model_name} is already provisioned in Domoticz", nwk_id,
         )
         return True
 
-    # Provisioned, but the reported model name changed: update in place
-    # without resetting the endpoints.
+    # reported model name changed: update in place without resetting the endpoints.
     self.log.logging(
         ["ZclClusters", "Pairing"], "Debug",
-        f"{nwk_id} - Update Model Name to {model_name} (keeping existing Ep/ClusterType)", nwk_id,
+        f"{nwk_id} - Update Model Name to {incoming_model_name} (keeping existing Ep/ClusterType)", nwk_id,
     )
-    device_info["Model"] = model_name
+    device_info["Model"] = incoming_model_name
 
-    if model_name in self.DeviceConf:
+    if incoming_model_name in self.DeviceConf:
         device_info["ConfigSource"] = "DeviceConf"
-        device_info["Param"] = dict(self.DeviceConf[model_name].get("Param", {}))
+        device_info["Param"] = dict(self.DeviceConf[incoming_model_name].get("Param", {}))
         device_info["CertifiedDevice"] = True
 
     return True
-
-def _is_device_already_provisioned(self, nwk_id, model_name):
-    """
-    Checks if the device is already provisioned in the system. If the device exists, updates its model name and configuration if necessary.
-
-    Parameters:
-        nwk_id (str): The network ID of the device.
-        model_name (str): The model name of the device.
-
-    Returns:
-        bool: True if the device is provisioned (or updated), False otherwise.
-    """
-
-    # Get device info using the network ID
-    device_info = self.ListOfDevices.get(nwk_id, {})
-
-    # If the device has no endpoints, it's not provisioned
-    if "Ep" not in device_info:
-        return False
-
-    # Iterate over each endpoint to check the device's provisioning status
-    for ep_id, ep_info in device_info["Ep"].items():
-        if "ClusterType" in ep_info:
-            self.log.logging(
-                ["ZclClusters", "Pairing"],
-                "Debug",
-                f"{nwk_id} / {ep_id} - {model_name} is already provisioned in Domoticz",
-                nwk_id
-            )
-
-            # If the device model matches, it's considered provisioned
-            if device_info.get("Model") == model_name:
-                return True
-
-            # Log the model name update and apply the new configuration
-            self.log.logging(
-                ["ZclClusters", "Pairing"],
-                "Debug",
-                f"{nwk_id} / {ep_id} - Update Model Name {model_name}",
-                nwk_id
-            )
-
-            # Update device information with the new model name
-            device_info["Model"] = model_name
-
-            # If the model is in DeviceConf, update its configuration
-            if model_name in self.DeviceConf:
-                device_info["ConfigSource"] = "DeviceConf"
-                device_info["Param"] = dict(self.DeviceConf[model_name].get("Param", {}))
-                device_info["CertifiedDevice"] = True
-
-            return True
-
-    # If no matching endpoint found or model was not updated
-    return False
 
 
 def _cleanup_model_name(msg_att_type, value):

--- a/Tools/repair_clustertype.py
+++ b/Tools/repair_clustertype.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Implementation of Zigbee for Domoticz plugin.
+#
+# This file is part of Zigbee for Domoticz plugin. https://github.com/zigbeefordomoticz/Domoticz-Zigbee
+# (C) 2015-2024
+#
+# Initial authors: zaraki673 & pipiche38
+#
+# SPDX-License-Identifier:    GPL-3.0 license
+
+"""
+Repair empty per-endpoint ``ClusterType`` cross-references (issue #1987).
+
+Background
+----------
+``ListOfDevices[nwk]["Ep"][ep]["ClusterType"]`` maps a Domoticz widget Idx to the
+widget type and is what lets the plugin push updates to the right widget. A long
+standing bug (fixed forward in ``Modules/zclClusterHelpers.py``) could wipe this map
+when a device re-announced its Model Name. Devices damaged *before* that fix keep
+replaying the empty map from the persisted ``DeviceList.txt``.
+
+This standalone, manually-run tool rebuilds the missing ``ClusterType`` entries from
+the Domoticz widgets that still exist in the Domoticz database. The widgets carry all
+the information we need:
+
+  - ``DeviceStatus.DeviceID``  -> the Zigbee IEEE address
+  - ``DeviceStatus.ID``        -> the Domoticz Idx == the ClusterType key
+  - ``DeviceStatus.Name``      -> ``[<NickName|Model>_]<cType>-<IEEE>-<EP>``
+                                  (see ``deviceName()`` in Modules/domoCreate.py)
+
+From the widget name we recover the endpoint (``EP``) and the widget type (``cType``)
+and re-register ``Ep[EP]["ClusterType"][str(Idx)] = cType`` for any endpoint whose
+ClusterType is currently empty/missing.
+
+Safety
+------
+- Dry-run by default: prints the proposed changes and writes nothing.
+- ``--apply`` is required to write, and a timestamped ``.bak`` copy is made first.
+- Only *adds* missing widget keys; never removes or overwrites an existing entry.
+
+Usage
+-----
+    # inspect (dry-run)
+    python3 Tools/repair_clustertype.py --db /path/to/domoticz.db --hwid 3 \
+        --devicelist /path/to/Data/DeviceList-3.txt
+
+    # actually write the repaired DeviceList
+    python3 Tools/repair_clustertype.py --db /path/to/domoticz.db --hwid 3 \
+        --devicelist /path/to/Data/DeviceList-3.txt --apply
+"""
+
+import argparse
+import ast
+import shutil
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+
+def load_widgets(db_path: Path, hwid: int):
+    """Return {ieee: [(idx, unit, name), ...]} for every widget of the given hardware."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT ID, DeviceID, Unit, Name FROM DeviceStatus WHERE HardwareID = ?",
+            (hwid,),
+        )
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
+
+    widgets = {}
+    for idx, device_id, unit, name in rows:
+        widgets.setdefault(str(device_id), []).append((str(idx), unit, name))
+    return widgets
+
+
+def load_devicelist_txt(path: Path):
+    """
+    Load a DeviceList.txt file into an ordered list of (nwkid, device_dict).
+
+    The file format is one device per line: ``<nwkid> : <python-dict-repr>`` (the same
+    format printed by Tools/printLOD.py).
+    """
+    devices = []
+    with open(path, "r") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            nwkid, raw = line.split(":", 1)
+            nwkid = nwkid.replace(" ", "").replace("'", "")
+            devices.append((nwkid, ast.literal_eval(raw)))  # nosec B307 - trusted local plugin data
+    return devices
+
+
+def parse_widget_name(name: str, model):
+    """
+    Recover (cType, ep) from a widget name ``[<NickName|Model>_]<cType>-<IEEE>-<EP>``.
+
+    Returns None when the name does not match the expected pattern.
+    """
+    if not name or name.count("-") < 2:
+        return None
+
+    # Endpoint and IEEE are the last two dash-separated tokens; cType values do not
+    # contain a dash, so a right split is unambiguous.
+    left, _ieee, ep = name.rsplit("-", 2)
+
+    # Strip the optional "<Model>_" / "<NickName>_" prefix. We know the Model from the
+    # device record; NickName is unknown here so we fall back to the last "_" segment.
+    if model and left.startswith("%s_" % model):
+        cluster_type = left[len(model) + 1:]
+    elif "_" in left:
+        cluster_type = left.rsplit("_", 1)[1]
+    else:
+        cluster_type = left
+
+    if not ep or not cluster_type:
+        return None
+    return cluster_type, ep
+
+
+def repair_device(nwkid, device, widgets):
+    """
+    Rebuild missing ClusterType entries for a single device in place.
+
+    Returns a list of human-readable change descriptions (empty if nothing to do).
+    """
+    changes = []
+
+    ieee = device.get("IEEE")
+    if not ieee or ieee not in widgets:
+        return changes
+    if "Ep" not in device or not isinstance(device["Ep"], dict):
+        return changes
+
+    model = device.get("Model")
+    model = model if isinstance(model, str) else None
+
+    for idx, _unit, name in widgets[ieee]:
+        parsed = parse_widget_name(name, model)
+        if parsed is None:
+            changes.append("  ?? %s / idx %s: cannot parse widget name '%s' - skipped" % (nwkid, idx, name))
+            continue
+        cluster_type, ep = parsed
+
+        if ep not in device["Ep"]:
+            changes.append("  ?? %s / idx %s: endpoint %s absent from DeviceList - skipped" % (nwkid, idx, ep))
+            continue
+
+        ep_record = device["Ep"][ep]
+        existing = ep_record.get("ClusterType")
+        if not isinstance(existing, dict):
+            ep_record["ClusterType"] = existing = {}
+
+        if idx in existing:
+            # Healthy entry, leave it untouched.
+            continue
+
+        existing[idx] = cluster_type
+        changes.append("  ++ %s ep %s: ClusterType['%s'] = '%s'  (from widget '%s')" % (nwkid, ep, idx, cluster_type, name))
+
+    return changes
+
+
+def write_devicelist_txt(path: Path, devices):
+    """Write the DeviceList back in the original one-device-per-line format."""
+    with open(path, "w") as handle:
+        for nwkid, device in devices:
+            handle.write("%s : %s\n" % (nwkid, str(device)))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Repair empty per-endpoint ClusterType from Domoticz widgets (issue #1987)")
+    parser.add_argument("--db", required=True, help="Path to the Domoticz database (domoticz.db)")
+    parser.add_argument("--hwid", required=True, type=int, help="Domoticz Hardware ID of the Zigbee plugin")
+    parser.add_argument("--devicelist", required=True, help="Path to the plugin DeviceList-<hwid>.txt to repair")
+    parser.add_argument("--apply", action="store_true", help="Write the repaired DeviceList (a .bak copy is made first)")
+    args = parser.parse_args()
+
+    db_path = Path(args.db)
+    devicelist_path = Path(args.devicelist)
+    if not db_path.exists():
+        print("Database file not found: %s" % db_path)
+        return
+    if not devicelist_path.exists():
+        print("DeviceList file not found: %s" % devicelist_path)
+        return
+
+    widgets = load_widgets(db_path, args.hwid)
+    if not widgets:
+        print("No widget found for Hardware ID %s - nothing to repair." % args.hwid)
+        return
+
+    devices = load_devicelist_txt(devicelist_path)
+
+    all_changes = []
+    for nwkid, device in devices:
+        all_changes.extend(repair_device(nwkid, device, widgets))
+
+    additions = [c for c in all_changes if c.lstrip().startswith("++")]
+    if not all_changes:
+        print("Nothing to repair: every device with widgets already has its ClusterType.")
+        return
+
+    print("Proposed ClusterType repairs:")
+    for change in all_changes:
+        print(change)
+    print("\n%d ClusterType entry(ies) to restore." % len(additions))
+
+    if not args.apply:
+        print("\nDry-run only. Re-run with --apply to write the changes.")
+        return
+
+    if not additions:
+        print("\nNo actual additions to write.")
+        return
+
+    backup = devicelist_path.with_suffix(devicelist_path.suffix + ".bak-%s" % datetime.now().strftime("%Y%m%d%H%M%S"))
+    shutil.copy2(devicelist_path, backup)
+    write_devicelist_txt(devicelist_path, devices)
+    print("\nBackup written to %s" % backup)
+    print("Repaired DeviceList written to %s" % devicelist_path)
+    print("Restart the plugin to reload the repaired DeviceList.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/Modules/test_clustertype_reenrollment.py
+++ b/tests/Modules/test_clustertype_reenrollment.py
@@ -109,6 +109,10 @@ def test_has_non_empty_cluster_type(zclch):
     assert zclch._has_non_empty_cluster_type({"Ep": {"01": {"ClusterType": {}}}}) is False
     assert zclch._has_non_empty_cluster_type({"Ep": {"01": {"0006": {}}}}) is False
     assert zclch._has_non_empty_cluster_type({"Ep": {}}) is False
+    # malformed record: a non-dict endpoint value must not raise (fail-safe probe)
+    assert zclch._has_non_empty_cluster_type({"Ep": {"01": "bogus"}}) is False
+    assert zclch._has_non_empty_cluster_type(
+        {"Ep": {"01": "bogus", "02": {"ClusterType": {"576": "ColorControl"}}}}) is True
 
 
 def test_has_provisioned_endpoint(zclch):

--- a/tests/Modules/test_clustertype_reenrollment.py
+++ b/tests/Modules/test_clustertype_reenrollment.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Regression tests for issue #1987: a Model Name re-announcement must never wipe the
+per-endpoint ``ClusterType`` cross-reference.
+
+Coverage:
+  - _cluster_type_pairs                          – snapshot helper
+  - _update_data_structutre_based_on_model_name  – ClusterType preserved on re-enrollment
+                                                   – missing DeviceConf clusters are added (superset)
+                                                   – empty ClusterType handled without crashing
+                                                   – already-DeviceConf config short-circuits
+                                                   – invariant tripwire logs an Error if ClusterType shrinks
+"""
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_stub(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def zclch():
+    """Import Modules.zclClusterHelpers with its external deps stubbed out."""
+    stubs = {
+        "Modules.pluginModels": _make_stub(
+            "Modules.pluginModels",
+            check_found_plugin_model=MagicMock(name="check_found_plugin_model"),
+            plugin_self_identifier=MagicMock(name="plugin_self_identifier"),
+        ),
+        "Modules.readAttributes": _make_stub(
+            "Modules.readAttributes",
+            ReadAttributeRequest_0702_multiplier_divisor=MagicMock(),
+        ),
+        "Modules.tools": _make_stub(
+            "Modules.tools",
+            get_deviceconf_parameter_value=MagicMock(return_value=None),
+        ),
+    }
+    saved = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    sys.modules.pop("Modules.zclClusterHelpers", None)
+    module = importlib.import_module("Modules.zclClusterHelpers")
+    yield module
+    for name, original in saved.items():
+        if original is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+    sys.modules.pop("Modules.zclClusterHelpers", None)
+
+
+class _FakeLog:
+    def __init__(self):
+        self.entries = []
+
+    def logging(self, module, level, message, nwkid=None, *args, **kwargs):
+        self.entries.append((level, message))
+
+    def levels(self):
+        return [level for level, _ in self.entries]
+
+
+class _FakeSelf:
+    def __init__(self):
+        self.ListOfDevices = {}
+        self.DeviceConf = {}
+        self.log = _FakeLog()
+        self.iaszonemgt = None
+
+
+NWK = "1234"
+MODEL = "MY-PLUG"
+
+
+def _deviceconf():
+    return {
+        MODEL: {
+            "Type": ["Switch"],
+            "Ep": {
+                "01": {"0006": {}, "0008": {}, "Type": ["Switch", "LvlControl"]},
+            },
+        }
+    }
+
+
+# ── _cluster_type_pairs ───────────────────────────────────────────────────────
+
+def test_cluster_type_pairs(zclch):
+    device = {"Ep": {
+        "01": {"ClusterType": {"576": "ColorControl", "577": "LvlControl"}},
+        "02": {"ClusterType": {"600": "Switch"}},
+        "03": {"ClusterType": {}},     # empty, contributes nothing
+        "04": {"0006": {}},            # no ClusterType key
+    }}
+    assert zclch._cluster_type_pairs(device) == {
+        ("01", "576"), ("01", "577"), ("02", "600"),
+    }
+
+
+# ── _update_data_structutre_based_on_model_name ──────────────────────────────
+
+def test_reenrollment_preserves_clustertype_and_adds_missing_clusters(zclch):
+    self = _FakeSelf()
+    self.DeviceConf = _deviceconf()
+    self.ListOfDevices[NWK] = {
+        "Model": MODEL,
+        "ConfigSource": "??",
+        "Ep": {"01": {"ClusterType": {"576": "ColorControl"}, "0006": {}}},
+    }
+
+    result = zclch._update_data_structutre_based_on_model_name(self, NWK, MODEL)
+
+    assert result is True
+    ep01 = self.ListOfDevices[NWK]["Ep"]["01"]
+    # ClusterType is untouched
+    assert ep01["ClusterType"] == {"576": "ColorControl"}
+    # DeviceConf clusters merged in as a superset (0008 added, 0006 kept)
+    assert "0006" in ep01 and "0008" in ep01
+    assert self.ListOfDevices[NWK]["ConfigSource"] == "DeviceConf"
+    # No Error logged
+    assert "Error" not in self.log.levels()
+
+
+def test_reenrollment_with_empty_clustertype_does_not_crash(zclch):
+    self = _FakeSelf()
+    self.DeviceConf = _deviceconf()
+    self.ListOfDevices[NWK] = {
+        "Model": MODEL,
+        "ConfigSource": "??",
+        "Ep": {"01": {"ClusterType": {}}},
+    }
+
+    result = zclch._update_data_structutre_based_on_model_name(self, NWK, MODEL)
+
+    assert result is True
+    assert self.ListOfDevices[NWK]["Ep"]["01"]["ClusterType"] == {}
+    assert "0008" in self.ListOfDevices[NWK]["Ep"]["01"]
+    assert "Error" not in self.log.levels()
+
+
+def test_already_deviceconf_short_circuits(zclch):
+    self = _FakeSelf()
+    self.DeviceConf = _deviceconf()
+    self.ListOfDevices[NWK] = {
+        "Model": MODEL,
+        "ConfigSource": "DeviceConf",
+        "Ep": {"01": {"ClusterType": {"576": "ColorControl"}}},
+    }
+
+    result = zclch._update_data_structutre_based_on_model_name(self, NWK, MODEL)
+
+    assert result is True
+    # Nothing enrolled: 0008 not added because we short-circuited
+    assert "0008" not in self.ListOfDevices[NWK]["Ep"]["01"]
+    assert self.ListOfDevices[NWK]["Ep"]["01"]["ClusterType"] == {"576": "ColorControl"}
+
+
+def test_unknown_model_returns_false(zclch):
+    self = _FakeSelf()
+    self.DeviceConf = {}
+    self.ListOfDevices[NWK] = {"Model": MODEL, "Ep": {}}
+    assert zclch._update_data_structutre_based_on_model_name(self, NWK, MODEL) is False
+
+
+def test_invariant_tripwire_fires_when_clustertype_shrinks(zclch, monkeypatch):
+    """If a future regression drops ClusterType during the merge, an Error must be logged."""
+    self = _FakeSelf()
+    self.DeviceConf = _deviceconf()
+    self.ListOfDevices[NWK] = {
+        "Model": MODEL,
+        "ConfigSource": "??",
+        "Ep": {"01": {"ClusterType": {"576": "ColorControl"}}},
+    }
+
+    def _destructive(self_, nwk, model, initial_ep):
+        # Simulate the historical bug: wipe the endpoint structure.
+        self_.ListOfDevices[nwk]["Ep"]["01"]["ClusterType"] = {}
+        return True
+
+    monkeypatch.setattr(zclch, "_upd_data_strut_based_on_model", _destructive)
+
+    zclch._update_data_structutre_based_on_model_name(self, NWK, MODEL)
+
+    assert "Error" in self.log.levels()
+    assert any("shrank" in message for _, message in self.log.entries)

--- a/tests/Modules/test_clustertype_reenrollment.py
+++ b/tests/Modules/test_clustertype_reenrollment.py
@@ -4,13 +4,20 @@
 Regression tests for issue #1987: a Model Name re-announcement must never wipe the
 per-endpoint ``ClusterType`` cross-reference.
 
+The protection strategy in the current code is *blocking* (not merging): when an
+endpoint already carries a non-empty ``ClusterType`` (real Domoticz widgets are
+provisioned), ``_update_data_structutre_based_on_model_name`` refuses to touch the
+``Ep`` structure at all and returns ``False``. Only when no provisioned ClusterType
+is present does it reset ``Ep`` and rebuild it from ``DeviceConf``.
+
 Coverage:
-  - _cluster_type_pairs                          – snapshot helper
-  - _update_data_structutre_based_on_model_name  – ClusterType preserved on re-enrollment
-                                                   – missing DeviceConf clusters are added (superset)
-                                                   – empty ClusterType handled without crashing
-                                                   – already-DeviceConf config short-circuits
-                                                   – invariant tripwire logs an Error if ClusterType shrinks
+  - _has_non_empty_cluster_type                  – endpoint provisioning probe
+  - _has_provisioned_endpoint                    – endpoint provisioning probe
+  - _update_data_structutre_based_on_model_name
+        – provisioned ClusterType blocks the Ep reset (Ep preserved, returns False)
+        – empty ClusterType allows the Ep reset/rebuild from DeviceConf
+        – already-DeviceConf config short-circuits untouched
+        – unknown model returns False
 """
 
 import importlib
@@ -93,23 +100,30 @@ def _deviceconf():
     }
 
 
-# ── _cluster_type_pairs ───────────────────────────────────────────────────────
+# ── provisioning probes ──────────────────────────────────────────────────────
 
-def test_cluster_type_pairs(zclch):
-    device = {"Ep": {
-        "01": {"ClusterType": {"576": "ColorControl", "577": "LvlControl"}},
-        "02": {"ClusterType": {"600": "Switch"}},
-        "03": {"ClusterType": {}},     # empty, contributes nothing
-        "04": {"0006": {}},            # no ClusterType key
-    }}
-    assert zclch._cluster_type_pairs(device) == {
-        ("01", "576"), ("01", "577"), ("02", "600"),
-    }
+def test_has_non_empty_cluster_type(zclch):
+    assert zclch._has_non_empty_cluster_type(
+        {"Ep": {"01": {"ClusterType": {"576": "ColorControl"}}}}) is True
+    # empty / missing ClusterType are NOT provisioned
+    assert zclch._has_non_empty_cluster_type({"Ep": {"01": {"ClusterType": {}}}}) is False
+    assert zclch._has_non_empty_cluster_type({"Ep": {"01": {"0006": {}}}}) is False
+    assert zclch._has_non_empty_cluster_type({"Ep": {}}) is False
+
+
+def test_has_provisioned_endpoint(zclch):
+    assert zclch._has_provisioned_endpoint(
+        {"Ep": {"01": {"ClusterType": {"576": "ColorControl"}}}}) is True
+    # an empty ClusterType mapping is falsy -> not provisioned
+    assert bool(zclch._has_provisioned_endpoint({"Ep": {"01": {"ClusterType": {}}}})) is False
+    assert bool(zclch._has_provisioned_endpoint({"Ep": {"01": {"0006": {}}}})) is False
 
 
 # ── _update_data_structutre_based_on_model_name ──────────────────────────────
 
-def test_reenrollment_preserves_clustertype_and_adds_missing_clusters(zclch):
+def test_reenrollment_with_provisioned_clustertype_is_blocked(zclch):
+    """A non-empty ClusterType must block the Ep reset: Ep is left fully intact
+    (missing DeviceConf clusters are NOT merged in) and the call returns False."""
     self = _FakeSelf()
     self.DeviceConf = _deviceconf()
     self.ListOfDevices[NWK] = {
@@ -120,18 +134,21 @@ def test_reenrollment_preserves_clustertype_and_adds_missing_clusters(zclch):
 
     result = zclch._update_data_structutre_based_on_model_name(self, NWK, MODEL)
 
-    assert result is True
+    assert result is False
     ep01 = self.ListOfDevices[NWK]["Ep"]["01"]
-    # ClusterType is untouched
+    # ClusterType is untouched and the Ep is not rebuilt from DeviceConf
     assert ep01["ClusterType"] == {"576": "ColorControl"}
-    # DeviceConf clusters merged in as a superset (0008 added, 0006 kept)
-    assert "0006" in ep01 and "0008" in ep01
+    assert "0006" in ep01
+    assert "0008" not in ep01          # DeviceConf cluster NOT merged because we bailed out
+    # ConfigSource is still flipped to DeviceConf before the guard
     assert self.ListOfDevices[NWK]["ConfigSource"] == "DeviceConf"
-    # No Error logged
-    assert "Error" not in self.log.levels()
+    # The protective bail-out is logged as a Warning mentioning the block
+    assert "Warning" in self.log.levels()
+    assert any("BLOCKED" in message for _, message in self.log.entries)
 
 
-def test_reenrollment_with_empty_clustertype_does_not_crash(zclch):
+def test_reenrollment_with_empty_clustertype_resets_and_rebuilds(zclch):
+    """With no provisioned ClusterType, Ep is reset and rebuilt from DeviceConf."""
     self = _FakeSelf()
     self.DeviceConf = _deviceconf()
     self.ListOfDevices[NWK] = {
@@ -142,9 +159,15 @@ def test_reenrollment_with_empty_clustertype_does_not_crash(zclch):
 
     result = zclch._update_data_structutre_based_on_model_name(self, NWK, MODEL)
 
+    # Successful reset/rebuild returns True (gates IAS re-registration in the caller).
     assert result is True
-    assert self.ListOfDevices[NWK]["Ep"]["01"]["ClusterType"] == {}
-    assert "0008" in self.ListOfDevices[NWK]["Ep"]["01"]
+    ep01 = self.ListOfDevices[NWK]["Ep"]["01"]
+    # Ep was wiped and rebuilt: DeviceConf clusters are present, the placeholder
+    # (empty) ClusterType key was dropped by the reset.
+    assert "0006" in ep01 and "0008" in ep01
+    assert "ClusterType" not in ep01
+    assert ep01["Type"] == ["Switch", "LvlControl"]
+    assert self.ListOfDevices[NWK]["ConfigSource"] == "DeviceConf"
     assert "Error" not in self.log.levels()
 
 
@@ -170,26 +193,3 @@ def test_unknown_model_returns_false(zclch):
     self.DeviceConf = {}
     self.ListOfDevices[NWK] = {"Model": MODEL, "Ep": {}}
     assert zclch._update_data_structutre_based_on_model_name(self, NWK, MODEL) is False
-
-
-def test_invariant_tripwire_fires_when_clustertype_shrinks(zclch, monkeypatch):
-    """If a future regression drops ClusterType during the merge, an Error must be logged."""
-    self = _FakeSelf()
-    self.DeviceConf = _deviceconf()
-    self.ListOfDevices[NWK] = {
-        "Model": MODEL,
-        "ConfigSource": "??",
-        "Ep": {"01": {"ClusterType": {"576": "ColorControl"}}},
-    }
-
-    def _destructive(self_, nwk, model, initial_ep):
-        # Simulate the historical bug: wipe the endpoint structure.
-        self_.ListOfDevices[nwk]["Ep"]["01"]["ClusterType"] = {}
-        return True
-
-    monkeypatch.setattr(zclch, "_upd_data_strut_based_on_model", _destructive)
-
-    zclch._update_data_structutre_based_on_model_name(self, NWK, MODEL)
-
-    assert "Error" in self.log.levels()
-    assert any("shrank" in message for _, message in self.log.entries)


### PR DESCRIPTION
## Problem (issue #1987)

A Zigbee device can re-announce its **Model Name** (cluster `0x0000`) at any time — on
rejoin, re-pair, or a battery check-in. The old `handle_model_name` path responded by
**wiping the device's `Ep` structure** and rebuilding it from `DeviceConf`. That reset
silently discarded the per-endpoint **`ClusterType`** map, which is the cross-reference
between Zigbee clusters and the Domoticz widgets. The result: existing widgets stopped
updating for already-provisioned devices.

## Fix strategy

Move from an unconditional *reset-and-rebuild* to a **guarded block-or-rebuild**: never
touch `Ep` once real widgets are provisioned.

The work landed across three commits:

- `f24ac46a` — initial guard: don't reset `Ep` if `ClusterType` is not empty
- `421cde32` — prevent the `Ep = {}` wipe entirely on the provisioned path
- `5218a66c` — review/cleanup of the guard + realigned unit tests

## Changes in `Modules/zclClusterHelpers.py`

### `_update_data_structutre_based_on_model_name(self, addr, model_name)`

Reworked control flow:

1. `model_name` not in `DeviceConf` → `return False`.
2. `ConfigSource == "DeviceConf"` already → short-circuit, `return True` (no re-enrollment).
3. Set `ConfigSource = "DeviceConf"`, copy `Param` and top-level `Type`.
4. **Guard:** if any endpoint has a non-empty `ClusterType`, log a `Warning`
   (`"Ep reset BLOCKED to protect provisioned ClusterType …"`) and `return False`.
   `Ep` is left **fully intact** — no merge, no reset.
5. Otherwise (no provisioned widgets): reset `Ep = {}` and rebuild from `DeviceConf`,
   now `return`ing the rebuild result (`True`) so the caller's IAS re-registration
   still fires.

- Signature now takes an explicit `model_name` argument instead of re-reading
  `self.ListOfDevices[addr]["Model"]`.

### New / renamed helpers

- **`_has_non_empty_cluster_type(device_info)`** — true if any endpoint has a
  `ClusterType` that is not `None`/`""`/`{}` (an empty map counts as *not* provisioned).
- **`_has_provisioned_endpoint(device_info)`** — truthiness probe for a `ClusterType` on
  any endpoint; hardened with an `isinstance(ep_info, dict)` check.
- **`_config_source_is_deviceconf(self, nwk_id)`** — small readability helper.
- **`_provision_or_update_existing_device(...)`** replaces the old
  `_is_device_already_provisioned(...)`: for an already-provisioned device it updates the
  Model Name/config **in place** (keeping `Ep`/`ClusterType`) and signals the caller to
  stop, rather than falling through to a reset.

### `_upd_data_strut_based_on_model(...)`

- Renamed loop variables (`device_conf_ep`, `device_conf_ep_info`) and added step
  comments (init EP → populate clusters → `Type` → `ColorMode`).
- Attribute-merge guard simplified to `if existing: continue` (don't overwrite
  already-populated attributes).

### `handle_model_name(...)`

- Renamed local `modelName` → `incoming_model_name` throughout for clarity (incoming
  report vs. the registered model).
- Downgraded the "different Model Name than registered" log from `Error` to `Warning`
  (expected, non-fatal).
- Fixed stale `_handle_model_name` log prefixes to `handle_model_name`; added
  explanatory comments.

## Tests — `tests/Modules/test_clustertype_reenrollment.py`

Realigned to the new contract (the old `_cluster_type_pairs` snapshot helper and
"shrank" Error tripwire were removed):

- `test_has_non_empty_cluster_type` / `test_has_provisioned_endpoint` — cover the new
  provisioning probes (empty `{}` ClusterType ⇒ not provisioned).
- `test_reenrollment_with_provisioned_clustertype_is_blocked` — non-empty `ClusterType`
  ⇒ returns `False`, `Ep` untouched (DeviceConf clusters **not** merged),
  `Warning`/`"BLOCKED"` logged.
- `test_reenrollment_with_empty_clustertype_resets_and_rebuilds` — empty `ClusterType`
  ⇒ `Ep` reset & rebuilt from `DeviceConf`, returns `True`.
- `test_already_deviceconf_short_circuits` — `ConfigSource == "DeviceConf"` ⇒ returns
  `True`, no changes.
- `test_unknown_model_returns_false` — model absent from `DeviceConf` ⇒ `False`.

**Result:** 6 passed.

## Behavior summary

| Device state on Model-Name report   | Old behavior            | New behavior                                          |
| ----------------------------------- | ----------------------- | ----------------------------------------------------- |
| Provisioned widgets (`ClusterType`) | `Ep` wiped, widgets broke | **Blocked** — `Ep`/`ClusterType` preserved, `False` |
| Already `ConfigSource=DeviceConf`   | Skipped                 | Skipped (`return True`)                               |
| Fresh device (no/empty `ClusterType`) | Rebuilt from `DeviceConf` | Rebuilt from `DeviceConf` (`return True`)           |
| Model changed but provisioned       | Reset                   | Model/config updated **in place**, `Ep` kept          |
