### PR TITLE
Fixing/group management

### DIFF
--- a/Classes/GroupMgtv2/GroupManagement.py
+++ b/Classes/GroupMgtv2/GroupManagement.py
@@ -59,7 +59,6 @@
 import json
 import os
 
-from Classes.GroupMgtv2.GrpMigration import GrpMgtv2Migration
 from Classes.GroupMgtv2.GrpServices import scan_device_for_grp_membership
 from Classes.LoggingManagement import LoggingManagement
 from Modules.zigateConsts import MAX_LOAD_ZIGATE

--- a/Classes/GroupMgtv2/GroupManagement.py
+++ b/Classes/GroupMgtv2/GroupManagement.py
@@ -56,11 +56,8 @@
 #      - Managing device short address changes ( could be better to store the IEEE )
 #
 
-import json
-import os
 
 from Classes.GroupMgtv2.GrpServices import scan_device_for_grp_membership
-from Classes.LoggingManagement import LoggingManagement
 from Modules.zigateConsts import MAX_LOAD_ZIGATE
 
 

--- a/Classes/GroupMgtv2/GroupManagement.py
+++ b/Classes/GroupMgtv2/GroupManagement.py
@@ -19,8 +19,8 @@
 #
 #  Group management rely on 2 files:
 #
-#  - ZigateGroupsConfig -xx.json which contains the Group configuration/definition
-#  - GroupsList-xx.pck which contains somehow a cash of what is available on each devices
+#  - ZigbeeGroupsConfig -xx.json which contains the Group configuration/definition
+#  - GroupsList-xx.pck which contains somehow a cache of what is available on each devices
 #                      (1) will be converted to a JSON format
 #
 #
@@ -42,8 +42,8 @@
 #
 #  SYNOPSIS
 #
-#  - At plugin start, if the group cash file exist, read and populate the data structure.
-#                     if the cash doesn't exist, request to each Main Powered device tfor their existing group membership.
+#  - At plugin start, if the group cache file exist, read and populate the data structure.
+#                     if the cache doesn't exist, request to each Main Powered device for their existing group membership.
 #                     collect the information and populate the data structure accordingly.
 #
 #  - When the data structure is fully loaded, the object will be full operational and able to handle the following request
@@ -119,7 +119,7 @@ class GroupsManagement(object):
         self.DeviceConf = DeviceConf
         self.ListOfGroups = {}  # Data structutre to store all groups
         self.log = log
-        self.GroupListFileName = None  # Filename of Group cashing file
+        self.GroupListFileName = None  # Filename of Group caching file
         self.ControllerIEEE = None
         self.ScanDevicesToBeDone = []  # List of Devices for which a GrpMemberShip request as to be performed
         self.GroupStatus = "Starting"  # Used by WebServer to display Status of Group!

--- a/Classes/GroupMgtv2/GrpDatabase.py
+++ b/Classes/GroupMgtv2/GrpDatabase.py
@@ -131,7 +131,7 @@ def checkNwkIdAndUpdateIfAny(self, NwkId, ieee):
     will return NwkId or an updated one in case of change of ShortId.
     will return None is the NwkId doesn't exist anymore
     """
-    if NwkId is self.ListOfDevices:
+    if NwkId in self.ListOfDevices:
         return NwkId
 
     # NwkId not found, let's check if the Ieee is stil there

--- a/Classes/GroupMgtv2/GrpDomoticz.py
+++ b/Classes/GroupMgtv2/GrpDomoticz.py
@@ -181,7 +181,7 @@ def create_domoticz_group_device(self, GroupName, GroupId):
         return
 
     if find_first_unit_widget_from_deviceID(self, self.Devices, GroupId):
-        self.logging( "Log", f"createDomoticzGroupDevice - {GroupId} exists alreday in Domoticz"  )
+        self.logging( "Log", f"createDomoticzGroupDevice - {GroupId} exists already in Domoticz"  )
         return
 
     Type_, Subtype_, SwitchType_ = best_group_widget(self, GroupId)
@@ -861,21 +861,21 @@ def processCommand(self, unit, GrpId, Command, Level, Color_):
             zcl_group_window_covering_on(self, GrpId, ZIGATE_EP, EPout)
             domo_update_api(self, self.Devices, GrpId, unit, nValue, sValue)
 
-        if Command in ( "On", "Open",):
+        elif Command in ( "On", "Open",):
             nValue = 1
             sValue = "100"
             zcl_group_window_covering_off(self, GrpId, ZIGATE_EP, EPout)
             update_device_list_attribute(self, GrpId, "0102", 100)
             domo_update_api(self, self.Devices, GrpId, unit, nValue, sValue)
 
-        if Command == "Stop":
+        elif Command == "Stop":
             nValue = 17
             sValue = "0"
             zcl_group_window_covering_stop(self, GrpId, ZIGATE_EP, EPout)
             update_device_list_attribute(self, GrpId, "0102", 50)
             domo_update_api(self, self.Devices, GrpId, unit, nValue, sValue)
 
-        if Command == "Set Level":
+        elif Command == "Set Level":
             nValue = 2
             sValue = str(Level)
             if is_device_inverted(self, GrpId):
@@ -886,7 +886,7 @@ def processCommand(self, unit, GrpId, Command, Level, Color_):
             zcl_group_window_covering_level(self, GrpId, ZIGATE_EP, EPout, level="%02x" %Level)
             domo_update_api(self, self.Devices, GrpId, unit, nValue, sValue)
 
-        resetDevicesHearttBeat(self, GrpId)
+        resetDevicesHeartBeat(self, GrpId)
         return
 
     # Old Fashon
@@ -1010,10 +1010,10 @@ def processCommand(self, unit, GrpId, Command, Level, Color_):
         domo_update_api(self, self.Devices, GrpId, unit, nValue, sValue, Color=Color_)
 
     # Request to force ReadAttribute to each devices part of that group
-    resetDevicesHearttBeat(self, GrpId)
+    resetDevicesHeartBeat(self, GrpId)
 
 
-def resetDevicesHearttBeat(self, GrpId):
+def resetDevicesHeartBeat(self, GrpId):
 
     if not self.pluginconf.pluginConf["forceGroupDeviceRefresh"]:
         return
@@ -1025,7 +1025,7 @@ def resetDevicesHearttBeat(self, GrpId):
                 NwkId = self.IEEE2NWK[Ieee]
             else:
                 self.logging(
-                    "Error", "resetDevicesHearttBeat - Hum Hum something wrong NwkId: %s Ieee %s" % (NwkId, Ieee)
+                    "Error", "resetDevicesHeartBeat - Hum Hum something wrong NwkId: %s Ieee %s" % (NwkId, Ieee)
                 )
 
         if NwkId in self.ListOfDevices:

--- a/Classes/GroupMgtv2/GrpMigration.py
+++ b/Classes/GroupMgtv2/GrpMigration.py
@@ -43,7 +43,7 @@ def migrateTupleToList(self, GrpId, tupleItem):
 
     if lenItem == 2:
         NwkId, Ep = tupleItem
-        if "IEEE" not in self.ListOfDevices[NwkId]:
+        if NwkId not in self.ListOfDevices or "IEEE" not in self.ListOfDevices[NwkId]:
             self.logging("Error", "For Group: %s unexpected Group Device %s droping" % (GrpId, str(tupleItem)))
             return
         Ieee = self.ListOfDevices[NwkId]["IEEE"]

--- a/Classes/GroupMgtv2/GrpServices.py
+++ b/Classes/GroupMgtv2/GrpServices.py
@@ -145,7 +145,10 @@ def add_group_member_ship_from_remote(self, NwkId, Ep, GroupId):
     checkToCreateOrUpdateGroup(self, NwkId, Ep, GroupId)
 
 def get_available_grp_id(self, start_range, stop_range):
-    for x in range(start_range, stop_range, -1):
+    # Single allocator for both ascending (WebUI) and descending (Legrand reserved
+    # band) ranges: the step direction is derived from start_range vs stop_range.
+    step = -1 if start_range > stop_range else 1
+    for x in range(start_range, stop_range, step):
         GrpId = "%04x" % x
         if GrpId not in self.ListOfGroups:
             return GrpId

--- a/Classes/GroupMgtv2/GrpWebServices.py
+++ b/Classes/GroupMgtv2/GrpWebServices.py
@@ -15,9 +15,9 @@ from time import time
 from Classes.GroupMgtv2.GrpIkeaRemote import Ikea5BToBeAddedToListIfExist
 from Classes.GroupMgtv2.GrpServices import (
     SendGroupIdentifyEffect, create_new_group_and_attach_devices,
-    scan_all_devices_for_grp_membership, submitForGroupMemberShipScaner,
-    update_group_and_add_devices, update_group_and_remove_devices,
-    updateGroupName)
+    get_available_grp_id, scan_all_devices_for_grp_membership,
+    submitForGroupMemberShipScaner, update_group_and_add_devices,
+    update_group_and_remove_devices, updateGroupName)
 from Modules.tools import getListOfEpForCluster, mainPoweredDevice
 
 
@@ -35,10 +35,10 @@ def ScanDevicesForGroupMemberShip(self, DevicesToScan):
             submitForGroupMemberShipScaner(self, NwkId, "01")
             continue
         if NwkId not in self.ListOfDevices:
-            self.logging("Debug", "ScanDevicesForGroupMemberShip : Skiping %s not existing" % NwkId)
+            self.logging("Debug", "ScanDevicesForGroupMemberShip : Skipping %s not existing" % NwkId)
             continue
         if not mainPoweredDevice(self, NwkId):
-            self.logging("Debug", "ScanDevicesForGroupMemberShip : Skiping %s not main powered" % NwkId)
+            self.logging("Debug", "ScanDevicesForGroupMemberShip : Skipping %s not main powered" % NwkId)
             continue
 
         ListEp = getListOfEpForCluster(self, NwkId, "0004")
@@ -112,10 +112,8 @@ def process_web_request(self, webInput):
 
 
 def get_group_id(self):
-    for x in range(0x0001, 0x0999):
-        GrpId = "%04x" % x
-        if GrpId not in self.ListOfGroups:
-            return GrpId
+    # Manually-created (WebUI) groups use the low ascending band.
+    return get_available_grp_id(self, 0x0001, 0x0999)
 
 
 def diff(first, second):
@@ -154,6 +152,9 @@ def newGroup(self, GrpName, item):
     self.logging("Debug", " --  -- - > Creation of Group: %s " % GrpName)
     # New Group to be added
     GrpId = get_group_id(self)
+    if GrpId is None:
+        self.logging("Error", " --  --  -- - > No available Group Id, cannot create Group: %s " % GrpName)
+        return
     self.logging("Debug", " --  --  -- - > GroupId: %s " % GrpId)
     self.logging("Debug", " --  --  -- - > DevicesSelected: %s " % item["devicesSelected"])
     DevicesList = []

--- a/Classes/GroupMgtv2/GrpWebServices.py
+++ b/Classes/GroupMgtv2/GrpWebServices.py
@@ -37,7 +37,7 @@ def ScanDevicesForGroupMemberShip(self, DevicesToScan):
         if NwkId not in self.ListOfDevices:
             self.logging("Debug", "ScanDevicesForGroupMemberShip : Skiping %s not existing" % NwkId)
             continue
-        if not mainPoweredDevice:
+        if not mainPoweredDevice(self, NwkId):
             self.logging("Debug", "ScanDevicesForGroupMemberShip : Skiping %s not main powered" % NwkId)
             continue
 

--- a/Classes/WebServer/rest_Groups.py
+++ b/Classes/WebServer/rest_Groups.py
@@ -276,6 +276,9 @@ def _zgroup_get(self, parameters):
                 ieee = self.ListOfDevices.get(dev, {}).get("IEEE", "")
             elif len(itemDevice) == 3:
                 dev, ep, ieee = itemDevice
+            else:
+                self.logging("Error", "_zgroup_get - Group %s skipping malformed device entry: %s" % (itergrp, itemDevice))
+                continue
             zgroup["Devices"].append( {"_NwkId": dev, "Ep": ep, "IEEE": ieee} )
 
         zgroup["Cluster"] = group_info.get("Cluster", "")

--- a/Classes/WebServer/rest_Groups.py
+++ b/Classes/WebServer/rest_Groups.py
@@ -87,13 +87,17 @@ def rest_zGroup_lst_avlble_dev(self, verb, data, parameters):
                     _device["WidgetList"].extend( widget )
 
         if "ClusterType" in device_entry:
+            # Legacy device-level ClusterType is not tied to a specific endpoint.
+            # Use the device's main endpoint (prefer "01") rather than the leaked
+            # `ep` left over from the loop above.
+            device_level_ep = "01" if "01" in device_entry_endpoints else next(iter(device_entry_endpoints), "01")
             clusterType = device_entry["ClusterType"]
 
             for widgetID in clusterType:
                 if clusterType[widgetID] not in LIST_CLUSTERTYPE_FOR_GROUPS:
                     continue
 
-                widget = _build_device_widgetList_infos( self, widgetID, ep, self.ListOfDevices[nwkid]["ZDeviceName"] )
+                widget = _build_device_widgetList_infos( self, widgetID, device_level_ep, self.ListOfDevices[nwkid]["ZDeviceName"] )
                 _device["WidgetList"].extend( widget)
 
         if _device not in device_lst:

--- a/Classes/WebServer/rest_Groups.py
+++ b/Classes/WebServer/rest_Groups.py
@@ -237,6 +237,9 @@ def rest_zGroup(self, verb, data, parameters):
     if verb == "PUT":
         return _zgroup_put( self, data, parameters)
 
+    # Unsupported verb: return the prepared (empty) response rather than None.
+    return _response
+
 
 def _zgroup_put( self, data, parameters):
     _response = prepResponseMessage(self, setupHeadersResponse())

--- a/Classes/WebServer/rest_Groups.py
+++ b/Classes/WebServer/rest_Groups.py
@@ -283,7 +283,12 @@ def _zgroup_get(self, parameters):
         zgroup["nValue"] = group_info.get("nValue", "")
         zgroup["sValue"] = group_info.get("sValue", "")
         if "Tradfri Remote" in group_info:
-            zgroup["Devices"].append(  {"_NwkId": group_info["Tradfri Remote"]} )
+            tradfri_remote = group_info["Tradfri Remote"]
+            zgroup["Devices"].append({
+                "_NwkId": tradfri_remote.get("Device Addr", ""),
+                "Ep": tradfri_remote.get("Ep", ""),
+                "IEEE": tradfri_remote.get("IEEE", ""),
+            })
 
         self.logging("Debug", f"Processed Group: {itergrp} {zgroup}")
     


### PR DESCRIPTION
| # | Issue | File | Status |
|---|-------|------|--------|
| 1 | `checkNwkIdAndUpdateIfAny` used `is` instead of `in` | `GrpDatabase.py:134` | ✅ Fixed |
| 2 | `mainPoweredDevice` referenced but not called | `GrpWebServices.py:40` | ✅ Fixed |
| — | `migrateTupleToList` `KeyError` on stale member | `GrpMigration.py:46` | ✅ Fixed (guarded) |
| — | Group-id allocator unified + exhaustion guard | `GrpServices.py` / `GrpWebServices.py` | ✅ Fixed |
| — | Cosmetic typos (`cash`, `Skiping`, `alreday`, `Hearttbeat`, `Zigate`) | several | ✅ Fixed |
| E | `Tradfri Remote` serialized as a dict in `_NwkId` | `rest_Groups.py:286` | ✅ Fixed |
| F | Unbound vars on unexpected device-tuple length | `rest_Groups.py:273` | ✅ Fixed |
| G | Leaked loop variable `ep` for device-level ClusterType | `rest_Groups.py:96` | ✅ Fixed |
| H | Implicit `None` return for unsupported verb | `rest_Groups.py:224` | ✅ Fixed |