### PR TITLE
A recoverable Domoticz failure (Accept New Hardware off, or no free unit) marked a device failDB, and the heartbeat then permanently deleted the whole device entry — losing Ep/Cluster/ClusterType

### DIFF
--- a/Modules/domoCreate.py
+++ b/Modules/domoCreate.py
@@ -248,6 +248,8 @@ def createDomoticzWidget( self, Devices, nwkid, ieee, ep, cType, widgetType=None
 
     unit = retreive_free_unit_for_widget(self, Devices, ieee)
     if unit is None:
+        # Recoverable: no free Domoticz unit. Mark so the heartbeat retries instead of deleting the device.
+        self.ListOfDevices[nwkid]["Status"] = "failDB_NoUnit"
         self.log.logging("WidgetCreation", "Error", "Domoticz widget creation failed. No available unit for device %s. Cannot create widget." % ieee)
         return None
 
@@ -260,7 +262,9 @@ def createDomoticzWidget( self, Devices, nwkid, ieee, ep, cType, widgetType=None
     myDev_ID = domo_create_api(self, Devices, ieee, unit, widgetName, widgetType=widgetType, Type_=Type_, Subtype_=Subtype_, Switchtype_=Switchtype_, widgetOptions=widgetOptions, Image=Image)
     
     if myDev_ID == -1:
-        self.ListOfDevices[nwkid]["Status"] = "failDB"
+        # Recoverable: Domoticz refused the creation (e.g. 'Accept New Hardware' is off).
+        # Mark so the heartbeat retries instead of deleting the device.
+        self.ListOfDevices[nwkid]["Status"] = "failDB_NoHardware"
         self.log.logging("WidgetCreation", "Error", "Domoticz widget creation failed. Check that Domoticz can Accept New Hardware [%s]" % myDev_ID)
         return None
 
@@ -514,6 +518,27 @@ def CreateDomoDevice(self, Devices, NWKID):
     self.widget_reuse_pool = {}
 
 
+def retry_failed_widget_creation(self, Devices, NwkId):
+    """Re-attempt a previously-failed (recoverable) widget creation.
+
+    A device left in ``failDB_NoUnit`` / ``failDB_NoHardware`` could not get its
+    widgets created because Domoticz refused new hardware or no free unit was
+    available. Both are recoverable, so the device is kept (its Ep/Cluster/
+    ClusterType are preserved) and creation is retried here. On success
+    CreateDomoDevice sets Status back to ``inDB``.
+
+    Widget-creation ownership stays in this module; the heartbeat only schedules
+    the call (see Modules/heartbeat.py).
+    """
+    status = self.ListOfDevices[NwkId].get("Status")
+    self.log.logging(
+        "WidgetCreation", "Status",
+        "Widget creation previously failed (%s) for %s - retrying. Check Domoticz 'Accept New "
+        "Hardware' setting and that free device units are available." % (status, NwkId),
+        NwkId)
+    CreateDomoDevice(self, Devices, NwkId)
+
+
 def update_device_type( self, NWKID, GlobalType ):
     self.log.logging("WidgetCreation", "Debug", "GlobalType: %s" % (str(GlobalType)), NWKID)
     if len(GlobalType) != 0:
@@ -569,7 +594,7 @@ def create_xcube_widgets(self, Devices, NWKID, DeviceID_IEEE, Ep, t):
     idx = domo_create_api(self, Devices, DeviceID_IEEE, unit, deviceName(self, NWKID, t, DeviceID_IEEE, Ep), Type_=244, Subtype_=62, Switchtype_=18, widgetOptions=Options)
     
     if idx == -1:
-        self.ListOfDevices[NWKID]["Status"] = "failDB"
+        self.ListOfDevices[NWKID]["Status"] = "failDB_NoHardware"
         self.log.logging("WidgetCreation", "Error", f"Domoticz widget creation failed. {DeviceID_IEEE} {Ep} {t} {unit}")
         return None
     else:
@@ -626,7 +651,7 @@ def create_switch_selector_widget( self, Devices, NWKID, DeviceID_IEEE, Ep, t):
     Options = createSwitchSelector(self, _num_level, DeviceType=t, OffHidden=_OffHidden, SelectorStyle=_SelectorStyle)
     unit = createDomoticzWidget(self, Devices, NWKID, DeviceID_IEEE, Ep, t, widgetOptions=Options)
     if unit is None:
-        self.ListOfDevices[NWKID]["Status"] = "failDB"
+        # Status (failDB_NoUnit / failDB_NoHardware) already set by createDomoticzWidget; don't clobber it.
         self.log.logging("WidgetCreation", "Error", f"Domoticz widget creation failed. {DeviceID_IEEE} {Ep} {t} {unit}")
         return None
 
@@ -682,7 +707,7 @@ def create_native_widget( self, Devices, NwkId, DeviceID_IEEE, Ep, widget_name):
                 widget_name, widget_record[ "widgetType" ], NwkId), NwkId)
             unit = createDomoticzWidget(self, Devices, NwkId, DeviceID_IEEE, Ep, widget_name, widget_record[ "widgetType" ])
             if unit is None:
-                self.ListOfDevices[NwkId]["Status"] = "failDB"
+                # Status (failDB_NoUnit / failDB_NoHardware) already set by createDomoticzWidget; don't clobber it.
                 self.log.logging("WidgetCreation", "Error", f"Domoticz widget creation failed. {DeviceID_IEEE} {Ep} {widget_record[ 'widgetType' ]} {unit}")
                 return None
             set_default_value( self, Devices, DeviceID_IEEE, unit, widget_record)
@@ -695,7 +720,7 @@ def create_native_widget( self, Devices, NwkId, DeviceID_IEEE, Ep, widget_name):
                 widget_name, widget_record[ "widgetType" ], NwkId), NwkId)
             unit = createDomoticzWidget(self, Devices, NwkId, DeviceID_IEEE, Ep, widget_name, widget_record[ "widgetType" ])
             if unit is None:
-                self.ListOfDevices[NwkId]["Status"] = "failDB"
+                # Status (failDB_NoUnit / failDB_NoHardware) already set by createDomoticzWidget; don't clobber it.
                 self.log.logging("WidgetCreation", "Error", f"Domoticz widget creation failed. {DeviceID_IEEE} {Ep} {widget_record[ 'widgetType' ]} {unit}")
                 return None
             set_default_value( self, Devices,DeviceID_IEEE, unit, widget_record)
@@ -708,7 +733,7 @@ def create_native_widget( self, Devices, NwkId, DeviceID_IEEE, Ep, widget_name):
                 widget_name, widget_record[ "widgetType" ], NwkId), NwkId)
             unit = createDomoticzWidget(self, Devices, NwkId, DeviceID_IEEE, Ep, widget_name, widget_record[ "widgetType" ])
             if unit is None:
-                self.ListOfDevices[NwkId]["Status"] = "failDB"
+                # Status (failDB_NoUnit / failDB_NoHardware) already set by createDomoticzWidget; don't clobber it.
                 self.log.logging("WidgetCreation", "Error", f"Domoticz widget creation failed. {DeviceID_IEEE} {Ep} {widget_record[ 'widgetType' ]} {unit}")
                 return None
 
@@ -734,7 +759,7 @@ def create_native_widget( self, Devices, NwkId, DeviceID_IEEE, Ep, widget_name):
         ForceClusterType=ForceClusterType
     )
     if unit is None:
-        self.ListOfDevices[NwkId]["Status"] = "failDB"
+        # Status (failDB_NoUnit / failDB_NoHardware) already set by createDomoticzWidget; don't clobber it.
         self.log.logging("WidgetCreation", "Error", f"Domoticz widget creation failed. {DeviceID_IEEE} {Ep} {Type} {Subtype} {Switchtype} {unit}")
         return None
 

--- a/Modules/heartbeat.py
+++ b/Modules/heartbeat.py
@@ -24,6 +24,7 @@ from DevicesModules.custom_Chameleon import erl_z3_master_info
 from Modules.basicOutputs import getListofAttribute
 from Modules.casaia import pollingCasaia
 from Modules.danfoss import danfoss_room_sensor_polling
+from Modules.domoCreate import retry_failed_widget_creation
 from Modules.domoticzAbstractLayer import (find_widget_unit_from_WidgetID,
                                            is_device_ieee_in_domoticz_db)
 from Modules.domoTools import (retrieve_widget_type_list,
@@ -91,6 +92,7 @@ ATTRIBUTE_DISCOVERY_REFRESH = (( 3600 // HEARTBEAT ) + 7)
 CHECKING_DELAY_READATTRIBUTE = (( 60 // HEARTBEAT ) + 7)
 PING_DEVICE_VIA_GROUPID = 3567 // HEARTBEAT    # Secondes ( 59minutes et 45 secondes )
 FIRST_PING_VIA_GROUP = 127 // HEARTBEAT
+WIDGET_CREATION_RETRY = 300 // HEARTBEAT       # Retry a recoverable widget-creation failure every 5 minutes
 CHECKING_TICMETER_KEY_ATTRIBUTES = (30 // HEARTBEAT)  # 30 Sec
 CHECKING_ERLZ3_KEY_ATTRIBUTES = ( 300 // HEARTBEAT )  # 5 Min
 
@@ -922,7 +924,18 @@ def processListOfDevices(self, Devices):
 
         status = device.get("Status", {})
         if status == "failDB":
+            # Terminal failure: incomplete entry that never paired. Safe to drop.
             entriesToBeRemoved.append(NwkId)
+            continue
+
+        if status in ("failDB_NoUnit", "failDB_NoHardware"):
+            # Recoverable widget-creation failure (Domoticz refused new hardware,
+            # or no free unit was available). Keep the device - deleting it would
+            # lose the whole entry (Ep/Cluster/ClusterType) - and let the creation
+            # module retry every 5 minutes so it self-heals once the user re-enables
+            # 'Accept New Hardware' / frees units.
+            if (int(device["Heartbeat"]) % WIDGET_CREATION_RETRY) == 0:
+                retry_failed_widget_creation(self, Devices, NwkId)
             continue
 
         # Known Devices

--- a/Modules/pairingProcess.py
+++ b/Modules/pairingProcess.py
@@ -393,7 +393,7 @@ def full_provision_device(self, Devices, NWKID, RIA, status):
         profalux_fake_deviceModel(self, NWKID)
 
     CreateDomoDevice(self, Devices, NWKID)
-    if self.ListOfDevices[NWKID]["Status"] not in ("inDB", "failDB"):
+    if self.ListOfDevices[NWKID]["Status"] != "inDB" and not self.ListOfDevices[NWKID]["Status"].startswith("failDB"):
         # Something went wrong in the Widget creation
         self.log.logging("Pairing", "Error","processNotinDBDevices - Creat Domo Device Failed !!! for %s status: %s" % (NWKID, self.ListOfDevices[NWKID]["Status"]))
         self.ListOfDevices[NWKID]["Status"] = "UNKNOW"


### PR DESCRIPTION
##  Fix — distinct failure statuses + ownership kept clean:

  - failDB → terminal only; heartbeat still deletes (legacy behavior preserved).
  - failDB_NoUnit / failDB_NoHardware → recoverable; device is kept and retried.

##  Files:
  1. domoCreate.py — createDomoticzWidget sets the precise status at each failure point (:252 NoUnit, :267 NoHardware; create_xcube_widgets:576 NoHardware); the 5 wrapper sites no longer clobber it. New
  retry_failed_widget_creation() owns the retry (logging + CreateDomoDevice).
  2. heartbeat.py — terminal failDB deletes; recoverable statuses dispatch to retry_failed_widget_creation() every 5 min (WIDGET_CREATION_RETRY = 300 // HEARTBEAT). Heartbeat schedules; domoCreate owns
  creation.
  3. pairingProcess.py:396 — accepts inDB or any failDB* so pairing doesn't overwrite with UNKNOW.
  4. database.py:809 — unchanged on purpose: terminal failDB stays skip-load; recoverable ones reload and retry after restart.
