### PR TITLE
Normalize user-facing Status log messages to a consistent present-tense, Z4D-prefixed voice across the active codebase

### DIFF
--- a/Classes/ConfigureReporting.py
+++ b/Classes/ConfigureReporting.py
@@ -489,9 +489,9 @@ class ConfigureReporting:
                             continue
                         
                         if not wip_flap:
-                            self.logging( "Status", f"------ We have detected a miss configuration reports for device {Nwkid} on ep {_ep} and cluster {_cluster}" ,nwkid=Nwkid)
+                            self.logging("Status", f"------ Z4D detects misconfigured reporting for device {Nwkid} on ep {_ep} and cluster {_cluster}", nwkid=Nwkid)
                         
-                        self.logging( "Status", f" - Attribut {attribut} request to force a Configure Reporting due to field {x} '{attribute_current_configuration[ x ]}' != '{cluster_configuration[ attribut ][ x]}'", nwkid=Nwkid)
+                        self.logging("Status", f" - Attribute {attribut} forces a Configure Reporting due to field {x} '{attribute_current_configuration[ x ]}' != '{cluster_configuration[ attribut ][ x]}'", nwkid=Nwkid)
                         configure_reporting_for_one_cluster(self, Nwkid, _ep, _cluster, True, cluster_configuration)
                         wip_flap = True
                         cluster_update = True

--- a/Classes/DomoticzDB.py
+++ b/Classes/DomoticzDB.py
@@ -107,7 +107,7 @@ class DomoticzAPIClient:
     def stop(self):
         """Stops the worker thread cleanly."""
         
-        self.logging("Status", "++ DomoticzDB Api thread stop requested")
+        self.logging("Status", "++ DomoticzDB API thread stop requested")
         self._stop_event.set()
         try:
             self._queue.put_nowait((0, None, None))   # sentinel with priority 0

--- a/Classes/GroupMgtv2/GrpDatabase.py
+++ b/Classes/GroupMgtv2/GrpDatabase.py
@@ -78,9 +78,9 @@ def load_groups_list_from_json(self):
         self.logging( "Debug", "Groups data loaded where saved on %s" % time.strftime("%A, %Y-%m-%d %H:%M:%S", time.localtime(dz_timestamp)), )
 
     if dz_timestamp >= txt_timestamp:
-        self.logging( "Status", "Z4D Loaded groups from Domoticz Db: %s" % len(self.ListOfGroups))
+        self.logging("Status", "Z4D loads groups from Domoticz Db: %s" % len(self.ListOfGroups))
     else:
-        self.logging( "Status", "Z4D Loaded groups from Json File: %s" % len(self.ListOfGroups))
+        self.logging("Status", "Z4D loads groups from Json File: %s" % len(self.ListOfGroups))
 
 
 def build_group_list_from_list_of_devices(self):

--- a/Classes/OTA.py
+++ b/Classes/OTA.py
@@ -1990,7 +1990,7 @@ def notify_ota_firmware_available(self, srcnwkid, manufcode, imagetype, filevers
 
     folder = next((OTA_CODES[supported_manufacturer]["Folder"] for supported_manufacturer in OTA_CODES if OTA_CODES[supported_manufacturer]["ManufCode"] == manufcode), None)
 
-    logging(self, "Status", "We have detected a potential new firmware for the device %s [%s]" %( get_device_nickname( self, NwkId=srcnwkid, ), srcnwkid ))
+    logging(self, "Status", "Z4D detects a potential new firmware for device %s [%s]" % ( get_device_nickname( self, NwkId=srcnwkid, ), srcnwkid ))
     logging(self, "Status", "   current version: %s" % fileversion)
     logging(self, "Status", "     firmware type: %s" % imagetype)
     logging(self, "Status", "    newest version: %s" % _ota_available["fileVersion"])

--- a/Classes/PluginConf.py
+++ b/Classes/PluginConf.py
@@ -626,9 +626,9 @@ def load_settings(self):
         self.pluginConf["ZigpyTopologyReport"] = False
     
     if dz_timestamp >= txt_timestamp:
-        Domoticz.Status( "Z4D Loaded pluginconf from Domoticz Db: %s" % len(self.pluginConf))
+        Domoticz.Status("Z4D loads pluginconf from Domoticz Db: %s" % len(self.pluginConf))
     else:
-        Domoticz.Status( "Z4D Loaded pluginconf from Json File: %s" % len(self.pluginConf))
+        Domoticz.Status("Z4D loads pluginconf from Json File: %s" % len(self.pluginConf))
 
 
 def _path_check(self):
@@ -678,7 +678,7 @@ def _path_check(self):
 
             if self.pluginConf[param] != str(_path_name):
                 if self.pluginConf["PosixPathUpdate"]:
-                    Domoticz.Status(f"Updating path from {self.pluginConf[param]} to {_path_name}")
+                    Domoticz.Status(f"Z4D updates path from {self.pluginConf[param]} to {_path_name}")
                     self.pluginConf[param] = str(_path_name)
                     update_done = True
                 else:

--- a/Classes/ZigpyTransport/AppGeneric.py
+++ b/Classes/ZigpyTransport/AppGeneric.py
@@ -259,7 +259,7 @@ async def initialize(self, *, auto_form: bool = False, force_form: bool = False)
             if _retrieved_backup is None:
                 await super(type(self),self).form_network()
             else:
-                self.log.logging( "Zigpy", "Status","++ Force Form: Restoring the most recent network backup")
+                self.log.logging("Zigpy", "Status", "++ Force Form: Restoring the most recent network backup")
                 await self.backups.restore_backup(  _retrieved_backup ) 
 
     # Load Network Information
@@ -272,16 +272,16 @@ async def initialize(self, *, auto_form: bool = False, force_form: bool = False)
         if not auto_form:
             raise
 
-        self.log.logging( "Zigpy", "Status","++ Forming a new network")
+        self.log.logging("Zigpy", "Status", "++ Forming a new network")
         await super(type(self),self).form_network()
 
         if _retrieved_backup is None:
             # Form a new network if we have no backup
-            self.log.logging( "Zigpy", "Status","++ Forming a new network with no backup")
+            self.log.logging("Zigpy", "Status", "++ Forming a new network with no backup")
             await self.form_network()
         else:
             # Otherwise, restore the most recent backup
-            self.log.logging( "Zigpy", "Status","++ Restoring the most recent network backup")
+            self.log.logging("Zigpy", "Status", "++ Restoring the most recent network backup")
             await self.backups.restore_backup( _retrieved_backup )
 
         await self.load_network_info(load_devices=True)

--- a/DevicesModules/custom_zlinky.py
+++ b/DevicesModules/custom_zlinky.py
@@ -174,7 +174,7 @@ def _zlinky_update_color(self, nwkid, op_tarifaire, previous_color, new_color):
 
         if ptect_value and ptect_value != new_color:
             # Looks like the PTEC info is not aligned with the current color !
-            self.log.logging("ZLinky", "Status", f"Requesting PTEC as not inline op_tarifaire: {op_tarifaire} ptec: {ptect_value} to prev_volor: {previous_color} new_color: {new_color}", nwkid)
+            self.log.logging("ZLinky", "Status", f"Z4D requests PTEC as not inline op_tarifaire: {op_tarifaire} ptec: {ptect_value} to prev_color: {previous_color} new_color: {new_color}", nwkid)
             ReadAttributeReq_Scheduled_ZLinky(self, nwkid)
             zlinky_color_tarif(self, nwkid, new_color)
         return
@@ -195,7 +195,7 @@ def _zlinky_update_color(self, nwkid, op_tarifaire, previous_color, new_color):
 
     self.log.logging("ZLinky", "Debug", f"_zlinky_update_color - LTARF >{ltarf_value}<", nwkid)
     if ltarf_value and ltarf_value != new_color:
-        self.log.logging("ZLinky", "Status", f"Requesting LTARF (0xff66) as not inline {ltarf_value} to {previous_color}/{new_color}", nwkid)
+        self.log.logging("ZLinky", "Status", f"Z4D requests LTARF (0xff66) as not inline {ltarf_value} to {previous_color}/{new_color}", nwkid)
         ReadAttributeRequest_ff66(self, nwkid)
         zlinky_color_tarif(self, nwkid, new_color)
 

--- a/Modules/basicOutputs.py
+++ b/Modules/basicOutputs.py
@@ -68,16 +68,16 @@ def ZigatePermitToJoin(self, permit):
         # Enable Permit to join
         if self.permitTojoin["Duration"] != 255:
             if permit != 255:
-                self.log.logging("BasicOutput", "Status", "Z4D opened the Zigbee network for %s seconds " % permit)
+                self.log.logging("BasicOutput", "Status", "Z4D opens the Zigbee network for %s seconds" % permit)
             else:
-                self.log.logging("BasicOutput", "Status", "Z4D opened the Zigbee network for ever ")
+                self.log.logging("BasicOutput", "Status", "Z4D opens the Zigbee network for ever")
 
             self.permitTojoin["Starttime"] = int(time())
             self.permitTojoin["Duration"] = 0 if permit <= 5 else permit
     else:
         self.permitTojoin["Starttime"] = int(time())
         self.permitTojoin["Duration"] = 0
-        self.log.logging("BasicOutput", "Status", "Z4D closed the Zigbee network")
+        self.log.logging("BasicOutput", "Status", "Z4D closes the Zigbee network")
 
     PermitToJoin(self, "%02x" % permit)
 
@@ -135,14 +135,14 @@ def start_Zigate(self, Mode="Controller"):
         # self.log.logging( "BasicOutput", "Status", "Set Zigate as a Coordinator" )
         # send_zigatecmd_raw(self, "0023","00")
 
-        self.log.logging("BasicOutput", "Status", "Force ZiGate to Normal mode")
+        self.log.logging("BasicOutput", "Status", "Z4D forces ZiGate to Normal mode")
         zigate_set_mode(self, 0x00)
 
-        self.log.logging("BasicOutput", "Status", "Start network")
+        self.log.logging("BasicOutput", "Status", "Z4D starts network")
         zigate_start_nwk(self)
         #send_zigatecmd_raw(self, "0024", "")  # Start Network
 
-        self.log.logging("BasicOutput", "Status", "Set Zigate as a TimeServer")
+        self.log.logging("BasicOutput", "Status", "Z4D sets Zigate as a TimeServer")
         setTimeServer(self)
 
         self.log.logging("BasicOutput", "Debug", "Request network Status")
@@ -320,7 +320,7 @@ def channelChangeInitiate(self, channel):
 
 def channelChangeContinue(self):
 
-    self.log.logging("BasicOutput", "Status", "Restart network")
+    self.log.logging("BasicOutput", "Status", "Z4D restarts network")
     #send_zigatecmd_raw(self, "0024", "")  # Start Network
     zigate_start_nwk(self)
     #send_zigatecmd_raw(self, "0009", "")  # In order to get Zigate IEEE and NetworkID
@@ -415,7 +415,7 @@ def leaveMgtReJoin(self, saddr, ieee, rejoin=True):
         _rmv_children = "01"
         _dnt_rmv_children = "00"
 
-        self.log.logging("BasicOutput", "Status", "Request a rejoin of (%s/%s)" % (saddr, ieee), saddr)
+        self.log.logging("BasicOutput", "Status", "Z4D requests a rejoin of (%s/%s)" % (saddr, ieee), saddr)
         return zdp_management_leave_request(self, saddr, ieee, _rejoin, _dnt_rmv_children)
 
 
@@ -497,7 +497,7 @@ def removeZigateDevice(self, IEEE):
         return None
 
     nwkid = self.IEEE2NWK[IEEE]
-    self.log.logging("BasicOutput", "Status", "Remove from Zigate Device = " + " IEEE = " + str(IEEE), nwkid)
+    self.log.logging("BasicOutput", "Status", "Z4D removes from Zigate Device - IEEE = " + str(IEEE), nwkid)
 
     # Do we have to remove a Router or End Device ?
     if mainPoweredDevice(self, nwkid):

--- a/Modules/checkingUpdate.py
+++ b/Modules/checkingUpdate.py
@@ -185,7 +185,7 @@ def _run_version_check(self, zigbee_communication, branch, zigate_model):
         if is_zigate_firmware_available(
             self, self.FirmwareMajorVersion, self.FirmwareVersion, firm_major, firm_minor
         ):
-            self.log.logging("Plugin", "Status", "Z4D found a newer Zigate Firmware version")
+            self.log.logging("Plugin", "Status", "Z4D finds a newer Zigate Firmware version")
             self.pluginParameters["FirmwareUpdate"] = True
 
     except Exception as e:

--- a/Modules/database.py
+++ b/Modules/database.py
@@ -217,7 +217,7 @@ def LoadDeviceList(self):
         # Keep the Size of the DeviceList in order to check changes
         self.DeviceListSize = os.path.getsize(device_list_txt_filename)
         
-    self.log.logging("Database", "Status", "Creating a versioned backup of %s" % device_list_txt_filename)
+    self.log.logging("Database", "Status", "Z4D creates a versioned backup of %s" % device_list_txt_filename)
     Modules.tools.rotate_file_versions(device_list_txt_filename, self.pluginconf.pluginConf["numDeviceListVersion"])
 
     cleanup_table_entries( self)
@@ -635,7 +635,7 @@ def importDeviceConf(self):
         if iterDevType == "":
             del self.DeviceConf[iterDevType]
 
-    self.log.logging("Database", "Status", "Z4D loaded %s configuration from legacy database." %len(self.DeviceConf))
+    self.log.logging("Database", "Status", "Z4D loads %s configuration from legacy database." % len(self.DeviceConf))
 
 
 def import_local_device_conf(self):
@@ -685,7 +685,7 @@ def import_local_device_conf(self):
                     self.log.logging( "Database", "Debug", "--> Config for %s" % ( str(device_model_name)) )
                     self.DeviceConf[device_model_name] = dict(model_definition)
                     
-                    self.log.logging( "Database", "Status", f"++ Overwrite standard configuration model {device_model_name} with {filename}" )
+                    self.log.logging("Database", "Status", f"++ Overwrite standard configuration model {device_model_name} with {filename}")
 
                     if "Identifier" in model_definition:
                         self.log.logging( "Database", "Debug", "--> Identifier found %s" % (str(model_definition["Identifier"])) )
@@ -862,7 +862,7 @@ def CheckDeviceList(self, key, val):
             OldModel = self.ListOfDevices[key][attribute]
             self.ListOfDevices[key][attribute] = self.ListOfDevices[key][attribute].replace("/", "")
             if OldModel != self.ListOfDevices[key][attribute]:
-                self.log.logging("Database", "Status", "Z4D adjusted Model from %s to %s" % (
+                self.log.logging("Database", "Status", "Z4D adjusts Model from %s to %s" % (
                     OldModel, self.ListOfDevices[key][attribute]))
 
     self.ListOfDevices[key]["Health"] = ""
@@ -1236,7 +1236,7 @@ def profalux_fix_remote_device_model(self):
         if self.ListOfDevices[x]["MacCapa"] != "80":
             continue
         if "Model" in self.ListOfDevices[x] and self.ListOfDevices[x]["Model"] != "Telecommande-Profalux":
-            self.log.logging( "Profalux", "Status", "Z4D forces Model Name from %s to %s" % (
+            self.log.logging("Profalux", "Status", "Z4D forces Model from %s to %s" % (
                 x, self.ListOfDevices[x]["Model"],), x)
             self.ListOfDevices[x]["Model"] = "Telecommande-Profalux"
 
@@ -1304,7 +1304,7 @@ def hack_ts0601_rename_model( self, nwkid, modelName, manufacturer_name):
     suggested_model = check_found_plugin_model( self, modelName, manufacturer_name=manufacturer_name, manufacturer_code=None, device_id=None )
     
     if self.ListOfDevices[ nwkid ][ 'Model' ] != suggested_model:
-        self.log.logging("Tuya", "Status", "Z4D adjusts Model name from %s to %s" %( modelName, suggested_model))
+        self.log.logging("Tuya", "Status", "Z4D adjusts Model from %s to %s" % (modelName, suggested_model))
         self.ListOfDevices[ nwkid ][ 'Model' ] = suggested_model
 
 

--- a/Modules/heartbeat.py
+++ b/Modules/heartbeat.py
@@ -341,7 +341,7 @@ def pollingManufSpecificDevices(self, NwkId, HB):
             if "ScheduledZLinkyRead" in self.ListOfDevices[NwkId]:
                 return
             if parameter == "ZLinkyPollingPTEC":
-                self.log.logging("Heartbeat", "Status", "Reading ZLinky Color of Day and Next Day")
+                self.log.logging("Heartbeat", "Status", "Z4D reads ZLinky Color of Day and Next Day")
 
             self.ListOfDevices[NwkId]["ScheduledZLinkyRead"] = True
             func = FUNC_MANUF[param]
@@ -1007,7 +1007,7 @@ def processListOfDevices(self, Devices):
         # if phase == 0:
         #    self.networkmap.start_scan( )
         if phase == 1:
-            self.log.logging("Heartbeat", "Status", "Starting Network Topology")
+            self.log.logging("Heartbeat", "Status", "Z4D starts Network Topology")
             self.networkmap.start_scan()
         elif phase == 2:
             self.log.logging( "Heartbeat", "Debug", "processListOfDevices Topology scan is possible %s" % self.ControllerLink.loadTransmit(), )

--- a/Modules/legrand_netatmo.py
+++ b/Modules/legrand_netatmo.py
@@ -266,7 +266,7 @@ def rejoin_legrand_reset(self):
         return
 
     # Send a Write Attributes no responses
-    self.log.logging( "Legrand", "Status", "Detected Legrand IEEE, broadcast Write Attribute 0x0000/0xf000")
+    self.log.logging( "Legrand", "Status", "Z4D detects Legrand IEEE, broadcasts Write Attribute 0x0000/0xf000")
     write_attributeNoResponse(self, "ffff", ZIGATE_EP, "01", "0000", "1021", "01", "f000", "23", "00000000")
 
 

--- a/Modules/linky.py
+++ b/Modules/linky.py
@@ -327,7 +327,7 @@ def collect_ticmeter_linky(self, nwkid):
             # Avoid repeated reads within 5 minutes
             return
 
-        self.log.logging("Pairing", "Status", "Reading TICMeter and collecting all data, as key data are missing")
+        self.log.logging("Pairing", "Status", "Z4D reads TICMeter and collects all data, as key data are missing")
 
         Modules.readAttributes.read_attributes_gammatroniques_tic_meter(self, nwkid)
         Modules.readAttributes.read_attributes_ticmeter_tarif(self, nwkid)

--- a/Modules/pairingProcess.py
+++ b/Modules/pairingProcess.py
@@ -743,7 +743,7 @@ def handle_device_specific_needs(self, Devices, NWKID):
 
     if device_model == "TICMeter":
         # Retreive as much attribuutes
-        self.log.logging("Pairing", "Status", "Reading TICMeter and collecting all data")
+        self.log.logging("Pairing", "Status", "Z4D reads TICMeter and collects all data")
         read_attributes_gammatroniques_tic_meter(self, NWKID)
         read_attributes_ticmeter_tarif(self, NWKID)
         read_attributes_ticmeter_details(self, NWKID)

--- a/Modules/piZigate.py
+++ b/Modules/piZigate.py
@@ -81,7 +81,7 @@ def runmode_with_gpiomodule(self):
 
         ei0 = GPIO.input(17)
         ei2 = GPIO.input(27)
-        self.log.logging("PiZigate", "Status", "Switch PiZigate in RUN mode")
+        self.log.logging("PiZigate", "Status", "Z4D switches PiZigate to RUN mode")
         if ei0:
             self.log.logging("PiZigate", "Log", " + GPIO(RUN) OK")
         else:

--- a/Modules/pluginHelpers.py
+++ b/Modules/pluginHelpers.py
@@ -128,7 +128,7 @@ def check_python_modules_version(self):
 def check_requirements(home_folder):
 
     requirements_file = Path(home_folder) / "constraints.txt"
-    Domoticz.Status("Checking Python modules %s" % requirements_file)
+    Domoticz.Status("Z4D checks Python modules %s" % requirements_file)
 
     with open(requirements_file, 'r') as file:
         requirements_list = file.readlines()

--- a/Modules/schneider_wiser.py
+++ b/Modules/schneider_wiser.py
@@ -176,7 +176,7 @@ def callbackDeviceAwake_Schneider(self, Devices, nwk_id, ep, cluster):
         and (schneider_data.get("ReportingMode") == "Fast" )
         and (schneider_data.get("Registration", 0) + FAST_REPORTING_INTERVAL) <= now
     ):
-        self.log.logging("Schneider", "Status", f"{nwk_id}/{ep} Switching Reporting to NORMAL mode")
+        self.log.logging("Schneider", "Status", f"{nwk_id}/{ep} switches Reporting to NORMAL mode")
         vact_config_reporting_normal(self, nwk_id, ep)
 
     # Handle override setpoint check for thermostats
@@ -2019,7 +2019,7 @@ def cancel_override_attribute( self, nwkid ):
     if "ThermostatOverride" not in self.ListOfDevices[nwkid][SCHNEIDER_META_DATA]:
         return
     nickname = get_device_nickname(self, NwkId=nwkid)
-    self.log.logging("Schneider", "Status", f"Cancelling temperature boost for device {nickname}", nwkid)
+    self.log.logging("Schneider", "Status", f"Z4D cancels temperature boost for device {nickname}", nwkid)
     
     del self.ListOfDevices[nwkid][SCHNEIDER_META_DATA]["ThermostatOverride"]
     self.ListOfDevices[nwkid ][SCHNEIDER_META_DATA]["BoostDemand"] = False
@@ -2102,7 +2102,7 @@ def override_setpoint(self, nwkid, ep, override, duration):
     schneider_meta_data["BoostDemand"] = True
     
     nickname = get_device_nickname(self, NwkId=nwkid)
-    self.log.logging("Schneider", "Status", f"Temperature boost for device {nickname} from {current_setpoint} to {override}", nwkid)
+    self.log.logging("Schneider", "Status", f"Z4D boosts temperature for device {nickname} from {current_setpoint} to {override}", nwkid)
 
     return override
 

--- a/Modules/tools_device_lifecycle.py
+++ b/Modules/tools_device_lifecycle.py
@@ -115,7 +115,7 @@ def remap_device_nwkid(self, new_NwkId: str, IEEE: str, old_NwkId: str) -> bool:
         self.ListOfDevices[new_NwkId]["Heartbeat"] = "0"
 
     request_flush_plugin_listofdevices(self)
-    self.log.logging("PluginTools", "Status", "NetworkID: %s is replacing %s for object: %s" % (new_NwkId, old_NwkId, IEEE))
+    self.log.logging("PluginTools", "Status", "NetworkID: %s replaces %s for object: %s" % (new_NwkId, old_NwkId, IEEE))
     return True
 
 

--- a/Modules/zigbeeController.py
+++ b/Modules/zigbeeController.py
@@ -18,7 +18,7 @@ from Modules.database import PLUGIN_DATABASE_RECORD_VERSION
 
 def initLODZigate(self, nwkid, ieee):
 
-    self.log.logging("Input", "Status", "Initialize Zigate Data Structure %s %s" % (nwkid, ieee))
+    self.log.logging("Input", "Status", "Z4D initializes Zigate Data Structure %s %s" % (nwkid, ieee))
     self.IEEE2NWK[ieee] = nwkid
     self.ListOfDevices[nwkid] = {
         'Version': PLUGIN_DATABASE_RECORD_VERSION,

--- a/Modules/zigpyBackup.py
+++ b/Modules/zigpyBackup.py
@@ -43,7 +43,7 @@ def handle_zigpy_backup(self, backup):
     store_in_domoticz_db = self.pluginconf.pluginConf.get("storeDomoticzDb")
     if use_domoticz_db or store_in_domoticz_db:
         domoticz_backup(self, json.dumps((backup.as_dict())))
-        self.log.logging("TransportZigpy", "Status", "Coordinator backup store in Domoticz")
+        self.log.logging("TransportZigpy", "Status", "Z4D stores Coordinator backup in Domoticz")
         
 
 def domoticz_backup(self, coordinator_backup):

--- a/Modules/zlinky.py
+++ b/Modules/zlinky.py
@@ -389,7 +389,7 @@ def update_zlinky_device_model_if_needed(self, nwkid):
             self.log.logging("ZLinky", "Log", f"Not authorized to adjust ZLinky model from {model_name} to {zlinky_conf}")
         return
 
-    self.log.logging("ZLinky", "Status", f"Adjusting ZLinky model from {model_name} to {zlinky_conf}")
+    self.log.logging("ZLinky", "Status", f"Z4D adjusts ZLinky model from {model_name} to {zlinky_conf}")
 
     # Update the model name
     device_info["Model"] = zlinky_conf

--- a/Modules/zosungIR.py
+++ b/Modules/zosungIR.py
@@ -295,7 +295,7 @@ def _ed00_cmd05_final(self, Devices, NwkId, srcEp, data_hex):
         return
 
     learned_code = base64.b64encode(bytes(rx_buffer)).decode("ascii")
-    self.log.logging("ZosungIR", "Status", "zosung IR Code received - NwkId: %s learned IR code len=%d '%s'" % (
+    self.log.logging("ZosungIR", "Status", "Z4D receives zosung IR Code - NwkId: %s, learned IR code len=%d '%s'" % (
         NwkId, len(learned_code), learned_code), NwkId)
 
     store_tuya_attribute(self, NwkId, "ZosungIR_learned_code", learned_code)

--- a/plugin.py
+++ b/plugin.py
@@ -360,10 +360,10 @@ class BasePlugin:
 
         mode6 = Parameters.get("Mode6", "0")
         if mode6.lstrip("-").isdigit():
-            Domoticz.Status( f"Enabling Debug Log Level: {mode6}")
+            Domoticz.Status(f"Enabling Debug Log Level: {mode6}")
             Domoticz.Debugging(int(mode6))
 
-        Domoticz.Status( "Welcome to Zigbee for Domoticz (Z4D) plugin. (c)pipiche38 - 2018 - 2026")
+        Domoticz.Status("Welcome to Zigbee for Domoticz (Z4D) plugin. (c)pipiche38 - 2018 - 2026")
 
         # Print PYTHONPATH if set
         pythonpath = os.getenv('PYTHONPATH')
@@ -462,7 +462,7 @@ class BasePlugin:
             return
 
         # Import PluginConf.txt
-        Domoticz.Status("Z4D is loading configuration settings")
+        Domoticz.Status("Z4D loads configuration settings")
         self.pluginconf = PluginConf(
             self.zigbee_communication, self.VersionNewFashion, self.DomoticzMajor, self.DomoticzMinor, Parameters["HomeFolder"], self.HardwareID
         )
@@ -474,7 +474,7 @@ class BasePlugin:
             self.internet_available = is_internet_available()
 
         if self.internet_available and self.pluginconf.pluginConf.get("CheckRequirements", True):
-            Domoticz.Status("Z4D is checking the python modules requirements")
+            Domoticz.Status("Z4D checks the Python modules requirements")
             if check_requirements( Parameters[ "HomeFolder"] ):
                 # Check_requirements() return True if requirements not meet.
                 self.onStop()
@@ -482,7 +482,7 @@ class BasePlugin:
 
         # Create Domoticz Sub menu
         if "DomoticzCustomMenu" in self.pluginconf.pluginConf and self.pluginconf.pluginConf["DomoticzCustomMenu"]:
-            Domoticz.Status("Z4D is installing the WebUI in the domoticz custom menu")
+            Domoticz.Status("Z4D installs the WebUI in the Domoticz custom menu")
             install_Z4D_to_domoticz_custom_ui( )
 
         # Create the adminStatusWidget if needed
@@ -503,7 +503,7 @@ class BasePlugin:
             self.log.openLogFile()
 
         # We can use from now the self.log.logging()
-        self.log.logging( "Plugin", "Status", "Z4D is starting with %s-%s and using DomoticzEx !" % (
+        self.log.logging("Plugin", "Status", "Z4D starts with %s-%s and using DomoticzEx !" % (
             self.pluginParameters["PluginBranch"], self.pluginParameters["PluginVersion"]), )
 
         # Debuging information
@@ -514,7 +514,7 @@ class BasePlugin:
  
         self.StartupFolder = Parameters["StartupFolder"]
 
-        Domoticz.Status("Z4D is initializing a connection to Domoticz Api/Json")
+        Domoticz.Status("Z4D initializes a connection to Domoticz API/JSON")
         self.domoticz_api = DomoticzAPIClient( Parameters["Mode5"], self.pluginconf, self.log)
         self.domoticz_device_cache = DomoticzDeviceCache(self.domoticz_api)
         
@@ -532,10 +532,10 @@ class BasePlugin:
             if sys.version_info < (3, 13):
                 # https://github.com/python/cpython/issues/91375
                 # Fixed in Python 3.13 via cpython/pull/104196 (freelist ported to module state)
-                self.log.logging("Plugin", "Status", "Z4D Multi-instances detected. Enabling 'asyncio' workaround")
+                self.log.logging("Plugin", "Status", "Z4D detects multiple instances, enabling 'asyncio' workaround")
                 sys.modules["_asyncio"] = None
             else:
-                self.log.logging("Plugin", "Status", "Z4D Multi-instances detected. Python 3.13+ — using native C asyncio.")
+                self.log.logging("Plugin", "Status", "Z4D detects multiple instances, using native C asyncio (Python 3.13+)")
 
         if "LogLevel" not in self.pluginParameters:
             log_level = self.domoticzdb_Hardware.get_loglevel_value()
@@ -574,7 +574,7 @@ class BasePlugin:
         load_list_of_domoticz_widget(self, Devices)
         
         # Import DeviceList.txt Filename is : DeviceListName
-        self.log.logging("Plugin", "Status", "Z4D loading plugin database")
+        self.log.logging("Plugin", "Status", "Z4D loads plugin database")
         if LoadDeviceList(self) == "Failed":
 
             self.log.logging("Plugin", "Error", "Something wennt wrong during the import of Load of Devices ...")
@@ -638,7 +638,7 @@ class BasePlugin:
             else:
                 self.log.logging( "Plugin", "Error", "WebServer disabled du to Parameter Mode4 set to %s" % Parameters["Mode4"] )
 
-        self.log.logging("Plugin", "Status", "Z4D starting with Domoticz 'Extended Framework'")
+        self.log.logging("Plugin", "Status", "Z4D starts with Domoticz 'Extended Framework'")
 
         self.busy = False
 
@@ -770,12 +770,12 @@ class BasePlugin:
 
                 # for a remove in case device didn't send the leave
                 zigate_remove_device(self, str(self.ControllerIEEE), str(DeviceID) )
-                self.log.logging( "Plugin", "Status", f"Request device {device_name} -> {DeviceID} to be removed from coordinator" )
+                self.log.logging("Plugin", "Status", f"Request device {device_name} -> {DeviceID} to be removed from coordinator")
 
             self.log.logging("Plugin", "Debug", f"ListOfDevices :After REMOVE {self.ListOfDevices}")
   
         elif self.groupmgt and DeviceID in self.groupmgt.ListOfGroups:
-            self.log.logging("Plugin", "Status", f"Request device {DeviceID} to be remove from Group(s)")
+            self.log.logging("Plugin", "Status", f"Request device {DeviceID} to be removed from Group(s)")
             self.groupmgt.FullRemoveOfGroup(Unit, DeviceID)
 
         load_list_of_domoticz_widget(self, Devices)
@@ -804,7 +804,7 @@ class BasePlugin:
             self.adminWidgets.updateStatusWidget(Devices, "Starting the plugin up")
 
         elif self.connectionState == 0:
-            self.log.logging("Plugin", "Status", "Z4D reconnected after failure")
+            self.log.logging("Plugin", "Status", "Z4D reconnects after failure")
             self.PluginHealth["Flag"] = 2
             self.PluginHealth["Txt"] = "Reconnecting after failure"
 
@@ -1163,7 +1163,7 @@ def retreive_zigpy_topology_data(self):
 
 def start_zigbee_transport(self ):
     # Connect to Coordinator only when all initialisation are properly done.
-    self.log.logging("Plugin", "Status", F"Z4D is starting transport Mode: '{self.transport}' Serial: '{Parameters['SerialPort']}' IP: '{Parameters['Address']} 'Port: '{Parameters['Port']}'")
+    self.log.logging("Plugin", "Status", f"Z4D starts transport Mode: '{self.transport}' Serial: '{Parameters['SerialPort']}' IP: '{Parameters['Address']} 'Port: '{Parameters['Port']}'")
 
     
     if self.transport in ("USB", "DIN", "V2-DIN", "V2-USB"):
@@ -1202,7 +1202,7 @@ def _start_zigpy_backend(self, backend_key):
     check_python_modules_version( self )
     self.zigbee_communication = "zigpy"
     self.pluginParameters["Zigpy"] = True
-    self.log.logging("Plugin", "Status", f"Z4D starting {label}")
+    self.log.logging("Plugin", "Status", f"Z4D starts {label}")
 
     if Parameters["Mode2"] == "Socket":
         SerialPort = "socket://" + Parameters["Address"] + ':' + Parameters["Port"]
@@ -1331,7 +1331,7 @@ def zigateInit_Phase1(self):
         zigate_erase_eeprom(self)
         if self.internet_available and self.pluginconf.pluginConf["MatomoOptIn"]:
             matomo_coordinator_initialisation(self)
-        self.log.logging("Plugin", "Status", "Z4D has erase the Zigate PDM")
+        self.log.logging("Plugin", "Status", "Z4D erases the Zigate PDM")
         #sendZigateCmd(self, "0012", "")
         self.PDMready = False
         self.startZigateNeeded = 1
@@ -1432,7 +1432,7 @@ def zigateInit_Phase3(self):
 
     # Set Certification Code
     if self.pluginconf.pluginConf["CertificationCode"] in CERTIFICATION:
-        self.log.logging( "Plugin", "Status", "Z4D coordinator set to Certification : %s/%s -> %s" % (
+        self.log.logging("Plugin", "Status", "Z4D coordinator set to Certification : %s/%s -> %s" % (
             self.pluginconf.pluginConf["CertificationCode"], self.pluginconf.pluginConf["Certification"], CERTIFICATION[self.pluginconf.pluginConf["CertificationCode"]],))
         #sendZigateCmd(self, "0019", "%02x" % self.pluginconf.pluginConf["CertificationCode"])
         zigate_set_certificate(self, "%02x" % self.pluginconf.pluginConf["CertificationCode"] )
@@ -1524,7 +1524,7 @@ def zigateInit_Phase3(self):
         self.iaszonemgt.setZigateIEEE(self.ControllerIEEE)
     
     if self.internet_available and self.pluginconf.pluginConf["MatomoOptIn"]:
-        self.log.logging("Plugin", "Status", "Z4D sending analytics information. (if you need to disable, disable the MatomoOptIn parameter via the WebUI - Settings)")
+        self.log.logging("Plugin", "Status", "Z4D sends analytics information. (if you need to disable, disable the MatomoOptIn parameter via the WebUI - Settings)")
         matomo_plugin_started(self)
 
     if self.internet_available and self.pluginconf.pluginConf["MatomoOptIn"]:
@@ -1601,7 +1601,7 @@ def start_OTAManagement(self, homefolder):
 
 def start_web_server(self, webserver_port, webserver_homefolder):
  
-    self.log.logging("Plugin", "Status", f"Z4D starting WebUI on port {webserver_port}" )
+    self.log.logging("Plugin", "Status", f"Z4D starts WebUI on port {webserver_port}")
     self.webserver = WebServer(
         self.zigbee_communication,
         self.ControllerData,
@@ -1704,7 +1704,7 @@ def pingZigate(self):
     if self.Ping["Status"] == "Receive":
         if self.connectionState == 0:
             # self.adminWidgets.updateStatusWidget( self, Devices, 'Ping: Reconnected after failure')
-            self.log.logging("Plugin", "Status", "Z4D - reconnected after failure")
+            self.log.logging("Plugin", "Status", "Z4D reconnects after failure")
         self.log.logging(
             "Plugin",
             "Debug",
@@ -1954,7 +1954,7 @@ def _post_readiness_startup_completed( self ):
                 # In case case, we have to set the extendedPANID
                 # ErasePDM has been requested, we are in the next Loop.
                 if self.ErasePDMDone and self.pluginconf.pluginConf["extendedPANID"] is not None:
-                    self.log.logging( "Plugin", "Status", "Z4D - Setting extPANID : 0x%016x" % (self.pluginconf.pluginConf["extendedPANID"]), )
+                    self.log.logging("Plugin", "Status", "Z4D sets extended PANID : 0x%016x" % (self.pluginconf.pluginConf["extendedPANID"]), )
                     setExtendedPANID(self, self.pluginconf.pluginConf["extendedPANID"])
 
                 start_Zigate(self)


### PR DESCRIPTION
 Normalize displayed Status log messages to a consistent voice

  Sweeps user-facing Status log messages (Domoticz.Status(...) and self.log.logging(..., "Status", ...)) across the active codebase into one consistent style:

  - Present-simple, third-person tense — is loading→loads, Loaded→loads, Reading→reads, Detected→detects, Cancelling→cancels, etc.
  - Z4D <verb-s> prefix for plugin-initiated actions (e.g. Start network→Z4D starts network).
  - Typo/grammar fixes — prev_volor→prev_color, Attribut→Attribute, Api/Json→API/JSON, miss configuration reports→misconfigured reporting.
  - Minor formatting — stray spaces, F"→f".

  Structured/tabular output, radio board-info dumps, pairing NEW OBJECT traces, and function-trace debug lines are left intact. Deprecated ZigateTransport and WebServer REST endpoints are out of
  scope.

  Log-string only — no functional change. flake8 (E9,F63,F7,F82) clean; 1280 tests pass.