### PR TITLE
Update zigpy upstream libs

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,8 +1,8 @@
-zigpy==1.5.1
+zigpy==2.1.0
 zigpy_znp==1.1.0
-zigpy_deconz==0.25.5
+zigpy_deconz==1.0.0
 zigpy-blz==0.1.0
-bellows==0.49.0
+bellows==1.0.0
 pyserial>=3.5
 serialx>=1.4.0
 charset-normalizer==2.0.11


### PR DESCRIPTION
### zigpy 1.5.1 → 2.1.0

- **Breaking:** quirks API moved out of zigpy into a separate package (2.0.0). Not used by this plugin — `Python/zigpy-quirks` setting in `PluginConf.py` is unread, and the `"zigpy.quirks"` logger name in `LoggingManagement.py` is a harmless no-op if the module is absent.
- Fix: cluster subclasses were silently dropping same-ID attribute/command definitions from the parent class (1.6.0).
- Fix: `_active_requests_by_tier` not decremented on success — a slow request-concurrency leak on long-running instances (2.0.1).
- OTA: images now cached per provider with combined index refreshes; extended timeout on final OTA image block; duplicate OTA provider registration skipped.
- Green Power: core ZGP types, frame, and crypto parsing (2.1.0).
- KeepAlive cluster support on the coordinator; Zigbee Direct Configuration cluster; coordinator group subscription APIs.
- Oversized attribute records are now sent instead of the request being rejected.

### bellows 0.49.0 → 1.0.0

- Simplicity SDK 2025.12.3 / EZSPv19 support.
- **Fix: "Event loop is closed" race condition in `EventLoopThread`** — relevant given the plugin's dedicated async zigpy thread and its shutdown path.
- `APS_Encryption` transmit option.
- Multicast group subscription API; combined XNCP unicast API.
- Startup reset wait increased to 2s for reliability.
- MTORR concentrator constants aligned with Silicon Labs SDK defaults.

### zigpy_deconz 0.25.5 → 1.0.0

- `APS_Encryption` transmit option support (pairs with the zigpy/bellows change above). No breaking changes.

### Notes for reviewers

- `zigpy_znp` and `zigpy-blz` are unchanged 
- No code changes required by the quirks removal since the plugin doesn't use `zigpy.quirks`.