### PR TITLE
Prepare stable8 -> stable9 migration tooling and end-of-life notice

### DIFF
--- a/Classes/WebServer/rest_PluginUpgrade.py
+++ b/Classes/WebServer/rest_PluginUpgrade.py
@@ -42,8 +42,8 @@ def rest_plugin_upgrade(self, verb, data, parameters):
     self.logging("Error", "************* IMPORTANT *************")
     self.logging("Error", "The 'stable8' branch no longer receives new features, only critical fixes.")
     self.logging("Error", "New development continues on 'stable9', built on the Domoticz Extended Framework.")
-    self.logging("Error", "To get further updates, run: Tools/plugin-switch-stable9.sh")
-    self.logging("Error", "This is a ONE-WAY move: there is no supported path back to 'stable8' afterwards.")
+    self.logging("Error", "To get further updates, run on the command line: Tools/plugin-switch-stable9.sh --i-understand")
+    self.logging("Error", "'stable8' is closed for new development: going back afterwards is not a supported path.")
     self.logging("Error", "************* IMPORTANT *************")
 
     self.logging("Log", "Plugin Upgrade starting: %s" %(upgrade_script))

--- a/Classes/WebServer/rest_PluginUpgrade.py
+++ b/Classes/WebServer/rest_PluginUpgrade.py
@@ -43,7 +43,7 @@ def rest_plugin_upgrade(self, verb, data, parameters):
     self.logging("Error", "The 'stable8' branch no longer receives new features, only critical fixes.")
     self.logging("Error", "New development continues on 'stable9', built on the Domoticz Extended Framework.")
     self.logging("Error", "To get further updates, run on the command line: Tools/plugin-switch-stable9.sh --i-understand")
-    self.logging("Error", "'stable8' is closed for new development: going back afterwards is not a supported path.")
+    self.logging("Error", "Any device paired after switching is created under the Extended Framework and is not usable back on 'stable8'.")
     self.logging("Error", "************* IMPORTANT *************")
 
     self.logging("Log", "Plugin Upgrade starting: %s" %(upgrade_script))

--- a/Classes/WebServer/rest_PluginUpgrade.py
+++ b/Classes/WebServer/rest_PluginUpgrade.py
@@ -39,6 +39,12 @@ def rest_plugin_upgrade(self, verb, data, parameters):
     # Identify the current Python version
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
     self.logging("Log", f"Current Python version: {python_version}")
+    self.logging("Error", "************* IMPORTANT *************")
+    self.logging("Error", "The 'stable8' branch no longer receives new features, only critical fixes.")
+    self.logging("Error", "New development continues on 'stable9', built on the Domoticz Extended Framework.")
+    self.logging("Error", "To get further updates, run: Tools/plugin-switch-stable9.sh")
+    self.logging("Error", "This is a ONE-WAY move: there is no supported path back to 'stable8' afterwards.")
+    self.logging("Error", "************* IMPORTANT *************")
 
     self.logging("Log", "Plugin Upgrade starting: %s" %(upgrade_script))
     

--- a/Tools/check_stable9_migration.py
+++ b/Tools/check_stable9_migration.py
@@ -6,47 +6,84 @@ Small helper that warns the user that the `stable8` branch is closed for
 new development and that `stable9` — built exclusively on the Domoticz
 Extended Framework (`DomoticzEx`) — is where updates continue.
 
-Unlike the earlier stable7 -> stable8 check, this is NOT a Python-version
-gate: `DomoticzEx` is a capability of the running Domoticz server itself
-and cannot be reliably probed from a standalone script outside of it.
-This tool therefore cannot silently decide "you're good to go" the way
-the old Python-version check could. Its job is to make sure the user has
-explicitly acknowledged the two facts that matter before anything is
-touched:
+The Extended Framework has been available in Domoticz since version
+2025.1, so unlike the earlier "cannot be probed" assumption, this script
+queries the running Domoticz server's own JSON API
+(`/json.htm?type=command&param=getversion`) to confirm the requirement
+is met, the same way any other Domoticz JSON API client (including this
+plugin) would.
 
-  1. `stable9` requires a Domoticz build with the Extended Framework
-     available and enabled for this hardware instance.
-  2. The move is a ONE-WAY DOOR. Once Domoticz (re)creates widgets under
-     the Extended Framework, the `stable8` plugin code can no longer
-     manage them — there is no supported path back to stable8 for an
-     installation that has switched.
+If Domoticz cannot be reached (wrong --ip/--port, not running, etc.) the
+script falls back to asking the user to confirm manually rather than
+silently assuming success.
+
+This tool cannot silently decide "you're good to go" for the second,
+more important fact: the move is a ONE-WAY DOOR. Once Domoticz
+(re)creates widgets under the Extended Framework, the `stable8` plugin
+code can no longer manage them — there is no supported path back to
+stable8 for an installation that has switched. Explicit confirmation is
+always required before the switch is suggested.
 
 Usage:
 
-    python3 Tools/check_stable9_migration.py [--yes] [--simulate|--no-simulate]
+    python3 Tools/check_stable9_migration.py [--ip 127.0.0.1] [--port 8080]
+                                              [--yes] [--simulate|--no-simulate]
 
-`--simulate` (default) only prints the warning and the manual command to
-run. `--no-simulate` additionally offers to invoke
-`Tools/plugin-switch-stable9.sh` once the user has typed the
-confirmation phrase.
+`--simulate` (default) only prints the notice and the manual command to
+run. `--no-simulate` additionally requires the user to type the
+confirmation phrase before pointing them at
+`Tools/plugin-switch-stable9.sh`.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
+from typing import Optional, Tuple
 
+try:
+    import requests
+except ImportError:
+    requests = None
+
+MIN_DOMOTICZ_VERSION = (2025, 1)  # DomoticzEx / Extended Framework available since 2025.1
+DEFAULT_IP = "127.0.0.1"
+DEFAULT_PORT = "8080"
+GET_TIMEOUT = 5
 CONFIRMATION_PHRASE = "I UNDERSTAND"
 
 
-def display_migration_notice() -> None:
+def get_domoticz_version(ip: str, port: str, timeout: int = GET_TIMEOUT) -> Optional[Tuple[int, int]]:
+    """Query the running Domoticz server's own JSON API for its version.
+
+    Returns a (year, release) tuple, e.g. (2025, 1), or None if Domoticz
+    could not be reached or the response could not be parsed.
+    """
+    if requests is None:
+        return None
+
+    url = f"http://{ip}:{port}/json.htm?type=command&param=getversion"
+    try:
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception:
+        return None
+
+    version_str = payload.get("version", "")
+    m = re.match(r"(\d+)\.(\d+)", version_str)
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)))
+
+
+def display_migration_notice(version_status: str) -> None:
     english = (
         "The 'stable8' branch is now closed for new features and only receives\n"
         "critical bug fixes. All new development continues on 'stable9', which is\n"
-        "built exclusively on the Domoticz Extended Framework (DomoticzEx).\n\n"
-        "Before switching, make sure that:\n"
-        "  - Your Domoticz server exposes the Extended Framework (check your\n"
-        "    Domoticz version and Settings) — the plugin will fail to start\n"
-        "    otherwise, as 'stable9' no longer supports the legacy widget model.\n\n"
+        "built exclusively on the Domoticz Extended Framework (DomoticzEx),\n"
+        "available since Domoticz 2025.1.\n\n"
+        f"{version_status}\n\n"
         "WARNING - THIS IS A ONE-WAY MOVE:\n"
         "  Once your devices are (re)created by Domoticz under the Extended\n"
         "  Framework, the 'stable8' plugin can no longer read or manage them.\n"
@@ -57,11 +94,7 @@ def display_migration_notice() -> None:
         "La branche 'stable8' est désormais fermée aux nouvelles fonctionnalités et\n"
         "ne reçoit plus que des correctifs critiques. Tous les nouveaux développements\n"
         "se poursuivent sur 'stable9', basée exclusivement sur le Framework Étendu de\n"
-        "Domoticz (DomoticzEx).\n\n"
-        "Avant de basculer, assurez-vous que :\n"
-        "  - Votre serveur Domoticz expose le Framework Étendu (vérifiez la version\n"
-        "    de Domoticz et ses paramètres) — sans cela, le plugin ne démarrera pas,\n"
-        "    car 'stable9' ne supporte plus l'ancien modèle de widgets.\n\n"
+        "Domoticz (DomoticzEx), disponible depuis Domoticz 2025.1.\n\n"
         "ATTENTION - CE BASCULEMENT EST IRRÉVERSIBLE :\n"
         "  Une fois vos périphériques recréés par Domoticz sous le Framework Étendu,\n"
         "  le plugin 'stable8' ne peut plus les lire ni les gérer. Il n'existe aucun\n"
@@ -76,13 +109,43 @@ def display_migration_notice() -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Warn about, and optionally trigger, the stable8 -> stable9 migration")
+    parser.add_argument("--ip", default=DEFAULT_IP, help=f"Domoticz server IP/host (default: {DEFAULT_IP})")
+    parser.add_argument("--port", default=DEFAULT_PORT, help=f"Domoticz web server port (default: {DEFAULT_PORT})")
+    parser.add_argument("--min-version", default="2025.1", help="Minimum required Domoticz version, e.g. 2025.1")
     parser.add_argument("--simulate", dest="simulate", action="store_true", help="Only display the notice (default)")
-    parser.add_argument("--no-simulate", dest="simulate", action="store_false", help="Offer to run the switch script after explicit confirmation")
+    parser.add_argument("--no-simulate", dest="simulate", action="store_false", help="Require confirmation before pointing to the switch script")
     parser.add_argument("--yes", "-y", dest="yes", action="store_true", help="Skip the interactive confirmation phrase (non-interactive use only)")
     parser.set_defaults(simulate=True)
     args = parser.parse_args()
 
-    display_migration_notice()
+    mv = args.min_version.split(".")
+    min_version = (int(mv[0]), int(mv[1]) if len(mv) > 1 else 0)
+
+    detected = get_domoticz_version(args.ip, args.port)
+
+    if detected is None:
+        version_status = (
+            f"Could not automatically verify the Domoticz version at http://{args.ip}:{args.port}\n"
+            "(server unreachable or response not understood). Please confirm manually,\n"
+            "via Setup > About in Domoticz, that your version is 2025.1 or newer before switching."
+        )
+        requirement_met = None  # unknown
+    elif detected >= min_version:
+        version_status = f"Detected Domoticz {detected[0]}.{detected[1]} at http://{args.ip}:{args.port} — Extended Framework requirement satisfied."
+        requirement_met = True
+    else:
+        version_status = (
+            f"Detected Domoticz {detected[0]}.{detected[1]} at http://{args.ip}:{args.port}, which is OLDER than the "
+            f"minimum required ({min_version[0]}.{min_version[1]}) for the Extended Framework.\n"
+            "Upgrade Domoticz itself before switching to 'stable9' — the plugin will fail to start otherwise."
+        )
+        requirement_met = False
+
+    display_migration_notice(version_status)
+
+    if requirement_met is False:
+        print("\nAborting: Domoticz version requirement not met. No changes made.")
+        raise SystemExit(1)
 
     if args.simulate:
         print("\nDry-run: to switch to 'stable9' run (manual):")

--- a/Tools/check_stable9_migration.py
+++ b/Tools/check_stable9_migration.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tools.check_stable9_migration
+
+Small helper that warns the user that the `stable8` branch is closed for
+new development and that `stable9` — built exclusively on the Domoticz
+Extended Framework (`DomoticzEx`) — is where updates continue.
+
+Unlike the earlier stable7 -> stable8 check, this is NOT a Python-version
+gate: `DomoticzEx` is a capability of the running Domoticz server itself
+and cannot be reliably probed from a standalone script outside of it.
+This tool therefore cannot silently decide "you're good to go" the way
+the old Python-version check could. Its job is to make sure the user has
+explicitly acknowledged the two facts that matter before anything is
+touched:
+
+  1. `stable9` requires a Domoticz build with the Extended Framework
+     available and enabled for this hardware instance.
+  2. The move is a ONE-WAY DOOR. Once Domoticz (re)creates widgets under
+     the Extended Framework, the `stable8` plugin code can no longer
+     manage them — there is no supported path back to stable8 for an
+     installation that has switched.
+
+Usage:
+
+    python3 Tools/check_stable9_migration.py [--yes] [--simulate|--no-simulate]
+
+`--simulate` (default) only prints the warning and the manual command to
+run. `--no-simulate` additionally offers to invoke
+`Tools/plugin-switch-stable9.sh` once the user has typed the
+confirmation phrase.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+CONFIRMATION_PHRASE = "I UNDERSTAND"
+
+
+def display_migration_notice() -> None:
+    english = (
+        "The 'stable8' branch is now closed for new features and only receives\n"
+        "critical bug fixes. All new development continues on 'stable9', which is\n"
+        "built exclusively on the Domoticz Extended Framework (DomoticzEx).\n\n"
+        "Before switching, make sure that:\n"
+        "  - Your Domoticz server exposes the Extended Framework (check your\n"
+        "    Domoticz version and Settings) — the plugin will fail to start\n"
+        "    otherwise, as 'stable9' no longer supports the legacy widget model.\n\n"
+        "WARNING - THIS IS A ONE-WAY MOVE:\n"
+        "  Once your devices are (re)created by Domoticz under the Extended\n"
+        "  Framework, the 'stable8' plugin can no longer read or manage them.\n"
+        "  There is no supported way back to 'stable8' after switching."
+    )
+
+    french = (
+        "La branche 'stable8' est désormais fermée aux nouvelles fonctionnalités et\n"
+        "ne reçoit plus que des correctifs critiques. Tous les nouveaux développements\n"
+        "se poursuivent sur 'stable9', basée exclusivement sur le Framework Étendu de\n"
+        "Domoticz (DomoticzEx).\n\n"
+        "Avant de basculer, assurez-vous que :\n"
+        "  - Votre serveur Domoticz expose le Framework Étendu (vérifiez la version\n"
+        "    de Domoticz et ses paramètres) — sans cela, le plugin ne démarrera pas,\n"
+        "    car 'stable9' ne supporte plus l'ancien modèle de widgets.\n\n"
+        "ATTENTION - CE BASCULEMENT EST IRRÉVERSIBLE :\n"
+        "  Une fois vos périphériques recréés par Domoticz sous le Framework Étendu,\n"
+        "  le plugin 'stable8' ne peut plus les lire ni les gérer. Il n'existe aucun\n"
+        "  chemin de retour supporté vers 'stable8' après le basculement."
+    )
+
+    print("=" * 78)
+    print("English:\n" + english + "\n")
+    print("Français:\n" + french)
+    print("=" * 78)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Warn about, and optionally trigger, the stable8 -> stable9 migration")
+    parser.add_argument("--simulate", dest="simulate", action="store_true", help="Only display the notice (default)")
+    parser.add_argument("--no-simulate", dest="simulate", action="store_false", help="Offer to run the switch script after explicit confirmation")
+    parser.add_argument("--yes", "-y", dest="yes", action="store_true", help="Skip the interactive confirmation phrase (non-interactive use only)")
+    parser.set_defaults(simulate=True)
+    args = parser.parse_args()
+
+    display_migration_notice()
+
+    if args.simulate:
+        print("\nDry-run: to switch to 'stable9' run (manual):")
+        print("    Tools/plugin-switch-stable9.sh")
+        return
+
+    print(f'\nTo continue, type exactly: {CONFIRMATION_PHRASE}')
+    if args.yes:
+        confirmed = True
+    else:
+        try:
+            answer = input("> ")
+        except EOFError:
+            answer = ""
+        confirmed = answer.strip() == CONFIRMATION_PHRASE
+
+    if not confirmed:
+        print("Confirmation not received. Aborted, no changes made.")
+        raise SystemExit(1)
+
+    print("Confirmation received. You may now run: Tools/plugin-switch-stable9.sh")
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/check_stable9_migration.py
+++ b/Tools/check_stable9_migration.py
@@ -20,10 +20,11 @@ script falls back to asking the user to confirm manually rather than
 silently assuming success.
 
 Switching itself is forward compatible: it does not modify or recreate
-any existing device. The one-way aspect is about support, not data:
-`stable8` is closed for new development, so once you move to `stable9`
-further updates and fixes only land there — going back is not a
-supported path going forward.
+any existing device. The one-way aspect kicks in afterwards: any device
+paired once running on `stable9` is created directly under the Extended
+Framework, and such new devices are not compatible with `stable8`'s
+legacy widget model — so going back stops being an option as soon as a
+new device is added.
 
 There are exactly two ways this script runs, and it never reads stdin:
 
@@ -99,9 +100,10 @@ def display_migration_notice(version_status: str) -> None:
         f"{version_status}\n\n"
         "NOTE - THIS MOVE IS FORWARD-ONLY:\n"
         "  Switching itself is forward compatible: it does not modify or recreate\n"
-        "  any of your existing devices. But 'stable8' is closed for new development,\n"
-        "  so once you switch, further updates and fixes only land on 'stable9' —\n"
-        "  going back to 'stable8' afterwards is not a supported path."
+        "  any of your existing devices. But any device you pair AFTER switching is\n"
+        "  created directly under the Extended Framework by 'stable9' — such new\n"
+        "  devices are not compatible with 'stable8's legacy widget model. Going\n"
+        "  back to 'stable8' stops being an option as soon as a new device is added."
     )
 
     french = (
@@ -111,10 +113,11 @@ def display_migration_notice(version_status: str) -> None:
         "Domoticz (DomoticzEx), disponible depuis Domoticz 2025.1.\n\n"
         "REMARQUE - CE BASCULEMENT EST À SENS UNIQUE :\n"
         "  Le basculement lui-même est rétrocompatible : il ne modifie ni ne recrée\n"
-        "  aucun de vos périphériques existants. Mais la branche 'stable8' étant fermée\n"
-        "  aux nouveaux développements, les prochaines mises à jour et correctifs ne\n"
-        "  seront disponibles que sur 'stable9' — revenir à 'stable8' ensuite n'est\n"
-        "  pas un chemin supporté."
+        "  aucun de vos périphériques existants. Mais tout périphérique appairé APRÈS\n"
+        "  le basculement est créé directement sous le Framework Étendu par 'stable9' —\n"
+        "  ces nouveaux périphériques ne sont pas compatibles avec l'ancien modèle de\n"
+        "  widgets de 'stable8'. Revenir à 'stable8' cesse d'être possible dès qu'un\n"
+        "  nouveau périphérique est ajouté."
     )
 
     print("=" * 78)

--- a/Tools/check_stable9_migration.py
+++ b/Tools/check_stable9_migration.py
@@ -7,35 +7,38 @@ new development and that `stable9` — built exclusively on the Domoticz
 Extended Framework (`DomoticzEx`) — is where updates continue.
 
 The Extended Framework has been available in Domoticz since version
-2025.1, so unlike the earlier "cannot be probed" assumption, this script
-queries the running Domoticz server's own JSON API
-(`/json.htm?type=command&param=getversion`) to confirm the requirement
-is met, the same way any other Domoticz JSON API client (including this
-plugin) would. It uses only the Python standard library (`urllib`) so
-it works with the system `python3` even when the plugin's virtualenv
-(and its `requests` dependency) isn't active — which is normally the
-case when this script is invoked outside the plugin.
+2025.1, so this script queries the running Domoticz server's own JSON
+API (`/json.htm?type=command&param=getversion`) to confirm the
+requirement is met, the same way any other Domoticz JSON API client
+(including this plugin) would. It uses only the Python standard library
+(`urllib`) so it works with the system `python3` even when the plugin's
+virtualenv (and its `requests` dependency) isn't active — which is
+normally the case when this script is invoked outside the plugin.
 
 If Domoticz cannot be reached (wrong --ip/--port, not running, etc.) the
 script falls back to asking the user to confirm manually rather than
 silently assuming success.
 
-This tool cannot silently decide "you're good to go" for the second,
-more important fact: the move is a ONE-WAY DOOR. Once Domoticz
-(re)creates widgets under the Extended Framework, the `stable8` plugin
-code can no longer manage them — there is no supported path back to
-stable8 for an installation that has switched. Explicit confirmation is
-always required before the switch is suggested.
+Switching itself is forward compatible: it does not modify or recreate
+any existing device. The one-way aspect is about support, not data:
+`stable8` is closed for new development, so once you move to `stable9`
+further updates and fixes only land there — going back is not a
+supported path going forward.
+
+There are exactly two ways this script runs, and it never reads stdin:
+
+  - No flags (the default): display-only. This is what the plugin's own
+    upgrade path (WebUI "Upgrade Plugin", plugin-auto-upgrade*.sh) uses
+    on every run — purely informational, no input expected, safe to run
+    unattended.
+  - `--i-understand`: an explicit, human-typed acknowledgement on the
+    command line that the switch may proceed. Only
+    `Tools/plugin-switch-stable9.sh` should be invoked this way, by a
+    person who read the notice and decided to switch.
 
 Usage:
 
-    python3 Tools/check_stable9_migration.py [--ip 127.0.0.1] [--port 8080]
-                                              [--yes] [--simulate|--no-simulate]
-
-`--simulate` (default) only prints the notice and the manual command to
-run. `--no-simulate` additionally requires the user to type the
-confirmation phrase before pointing them at
-`Tools/plugin-switch-stable9.sh`.
+    python3 Tools/check_stable9_migration.py [--ip 127.0.0.1] [--port 8080] [--i-understand]
 """
 
 from __future__ import annotations
@@ -51,7 +54,6 @@ MIN_DOMOTICZ_VERSION = (2025, 1)  # DomoticzEx / Extended Framework available si
 DEFAULT_IP = "127.0.0.1"
 DEFAULT_PORT = "8080"
 GET_TIMEOUT = 5
-CONFIRMATION_PHRASE = "I UNDERSTAND"
 
 
 def get_domoticz_version(ip: str, port: str, timeout: int = GET_TIMEOUT) -> Tuple[Optional[Tuple[int, int]], Optional[str]]:
@@ -95,10 +97,11 @@ def display_migration_notice(version_status: str) -> None:
         "built exclusively on the Domoticz Extended Framework (DomoticzEx),\n"
         "available since Domoticz 2025.1.\n\n"
         f"{version_status}\n\n"
-        "WARNING - THIS IS A ONE-WAY MOVE:\n"
-        "  Once your devices are (re)created by Domoticz under the Extended\n"
-        "  Framework, the 'stable8' plugin can no longer read or manage them.\n"
-        "  There is no supported way back to 'stable8' after switching."
+        "NOTE - THIS MOVE IS FORWARD-ONLY:\n"
+        "  Switching itself is forward compatible: it does not modify or recreate\n"
+        "  any of your existing devices. But 'stable8' is closed for new development,\n"
+        "  so once you switch, further updates and fixes only land on 'stable9' —\n"
+        "  going back to 'stable8' afterwards is not a supported path."
     )
 
     french = (
@@ -106,10 +109,12 @@ def display_migration_notice(version_status: str) -> None:
         "ne reçoit plus que des correctifs critiques. Tous les nouveaux développements\n"
         "se poursuivent sur 'stable9', basée exclusivement sur le Framework Étendu de\n"
         "Domoticz (DomoticzEx), disponible depuis Domoticz 2025.1.\n\n"
-        "ATTENTION - CE BASCULEMENT EST IRRÉVERSIBLE :\n"
-        "  Une fois vos périphériques recréés par Domoticz sous le Framework Étendu,\n"
-        "  le plugin 'stable8' ne peut plus les lire ni les gérer. Il n'existe aucun\n"
-        "  chemin de retour supporté vers 'stable8' après le basculement."
+        "REMARQUE - CE BASCULEMENT EST À SENS UNIQUE :\n"
+        "  Le basculement lui-même est rétrocompatible : il ne modifie ni ne recrée\n"
+        "  aucun de vos périphériques existants. Mais la branche 'stable8' étant fermée\n"
+        "  aux nouveaux développements, les prochaines mises à jour et correctifs ne\n"
+        "  seront disponibles que sur 'stable9' — revenir à 'stable8' ensuite n'est\n"
+        "  pas un chemin supporté."
     )
 
     print("=" * 78)
@@ -119,14 +124,12 @@ def display_migration_notice(version_status: str) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Warn about, and optionally trigger, the stable8 -> stable9 migration")
+    parser = argparse.ArgumentParser(description="Display, and optionally acknowledge, the stable8 -> stable9 migration notice")
     parser.add_argument("--ip", default=DEFAULT_IP, help=f"Domoticz server IP/host (default: {DEFAULT_IP})")
     parser.add_argument("--port", default=DEFAULT_PORT, help=f"Domoticz web server port (default: {DEFAULT_PORT})")
     parser.add_argument("--min-version", default="2025.1", help="Minimum required Domoticz version, e.g. 2025.1")
-    parser.add_argument("--simulate", dest="simulate", action="store_true", help="Only display the notice (default)")
-    parser.add_argument("--no-simulate", dest="simulate", action="store_false", help="Require confirmation before pointing to the switch script")
-    parser.add_argument("--yes", "-y", dest="yes", action="store_true", help="Skip the interactive confirmation phrase (non-interactive use only)")
-    parser.set_defaults(simulate=True)
+    parser.add_argument("--i-understand", dest="i_understand", action="store_true",
+                         help="Explicit human acknowledgement that the switch may proceed. Never pass this from an automated/unattended caller.")
     args = parser.parse_args()
 
     mv = args.min_version.split(".")
@@ -165,26 +168,13 @@ def main() -> None:
         print("\nAborting: Domoticz version requirement not met. No changes made.")
         raise SystemExit(1)
 
-    if args.simulate:
-        print("\nDry-run: to switch to 'stable9' run (manual):")
-        print("    Tools/plugin-switch-stable9.sh")
+    if not args.i_understand:
+        print("\nThis is informational only, no changes were made.")
+        print("To switch to 'stable9', re-run explicitly on the command line:")
+        print("    Tools/plugin-switch-stable9.sh --i-understand")
         return
 
-    print(f'\nTo continue, type exactly: {CONFIRMATION_PHRASE}')
-    if args.yes:
-        confirmed = True
-    else:
-        try:
-            answer = input("> ")
-        except EOFError:
-            answer = ""
-        confirmed = answer.strip() == CONFIRMATION_PHRASE
-
-    if not confirmed:
-        print("Confirmation not received. Aborted, no changes made.")
-        raise SystemExit(1)
-
-    print("Confirmation received. You may now run: Tools/plugin-switch-stable9.sh")
+    print("\nAcknowledgement received (--i-understand). Proceeding is now allowed.")
 
 
 if __name__ == "__main__":

--- a/Tools/check_stable9_migration.py
+++ b/Tools/check_stable9_migration.py
@@ -139,7 +139,13 @@ def main() -> None:
             f"Could not automatically verify the Domoticz version: {error}\n"
             "Please confirm manually, via Setup > About in Domoticz, that your version\n"
             "is 2025.1 or newer before switching. If Domoticz runs on a different host/port,\n"
-            "pass --ip/--port."
+            "pass --ip/--port.\n"
+            "If Domoticz runs in a Docker container and this script was run from the Docker\n"
+            "HOST (not via 'docker compose exec'), 127.0.0.1 on the host only reaches Domoticz\n"
+            "if that port is published to the host. Either run this script inside the\n"
+            "container (e.g. 'docker compose exec <container> bash -c \"cd <plugin_dir> &&\n"
+            "Tools/plugin-switch-stable9.sh\"', matching Tools/update_domoticz_docker_container.sh),\n"
+            "or pass --ip/--port matching the host-published address."
         )
         requirement_met = None  # unknown
     elif detected >= min_version:

--- a/Tools/check_stable9_migration.py
+++ b/Tools/check_stable9_migration.py
@@ -11,7 +11,10 @@ The Extended Framework has been available in Domoticz since version
 queries the running Domoticz server's own JSON API
 (`/json.htm?type=command&param=getversion`) to confirm the requirement
 is met, the same way any other Domoticz JSON API client (including this
-plugin) would.
+plugin) would. It uses only the Python standard library (`urllib`) so
+it works with the system `python3` even when the plugin's virtualenv
+(and its `requests` dependency) isn't active — which is normally the
+case when this script is invoked outside the plugin.
 
 If Domoticz cannot be reached (wrong --ip/--port, not running, etc.) the
 script falls back to asking the user to confirm manually rather than
@@ -38,13 +41,11 @@ confirmation phrase before pointing them at
 from __future__ import annotations
 
 import argparse
+import json
 import re
+import urllib.error
+import urllib.request
 from typing import Optional, Tuple
-
-try:
-    import requests
-except ImportError:
-    requests = None
 
 MIN_DOMOTICZ_VERSION = (2025, 1)  # DomoticzEx / Extended Framework available since 2025.1
 DEFAULT_IP = "127.0.0.1"
@@ -53,28 +54,38 @@ GET_TIMEOUT = 5
 CONFIRMATION_PHRASE = "I UNDERSTAND"
 
 
-def get_domoticz_version(ip: str, port: str, timeout: int = GET_TIMEOUT) -> Optional[Tuple[int, int]]:
+def get_domoticz_version(ip: str, port: str, timeout: int = GET_TIMEOUT) -> Tuple[Optional[Tuple[int, int]], Optional[str]]:
     """Query the running Domoticz server's own JSON API for its version.
 
-    Returns a (year, release) tuple, e.g. (2025, 1), or None if Domoticz
-    could not be reached or the response could not be parsed.
+    Returns a (version, error) tuple: version is a (year, release) tuple,
+    e.g. (2025, 1), when successfully parsed, else None. error is a
+    human-readable explanation of what went wrong, or None on success.
     """
-    if requests is None:
-        return None
-
     url = f"http://{ip}:{port}/json.htm?type=command&param=getversion"
     try:
-        response = requests.get(url, timeout=timeout)
-        response.raise_for_status()
-        payload = response.json()
-    except Exception:
-        return None
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            status = response.status
+            body = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        return None, f"HTTP {e.code} response from {url} (is authentication enabled on Domoticz?)"
+    except urllib.error.URLError as e:
+        return None, f"could not connect to {url} ({e.reason})"
+    except Exception as e:
+        return None, f"request to {url} failed ({e})"
+
+    if status != 200:
+        return None, f"HTTP {status} response from {url}"
+
+    try:
+        payload = json.loads(body)
+    except Exception as e:
+        return None, f"response from {url} was not valid JSON ({e}); got: {body[:120]!r}"
 
     version_str = payload.get("version", "")
     m = re.match(r"(\d+)\.(\d+)", version_str)
     if not m:
-        return None
-    return (int(m.group(1)), int(m.group(2)))
+        return None, f"'version' field missing or unparseable in response from {url}: {payload}"
+    return (int(m.group(1)), int(m.group(2))), None
 
 
 def display_migration_notice(version_status: str) -> None:
@@ -121,13 +132,14 @@ def main() -> None:
     mv = args.min_version.split(".")
     min_version = (int(mv[0]), int(mv[1]) if len(mv) > 1 else 0)
 
-    detected = get_domoticz_version(args.ip, args.port)
+    detected, error = get_domoticz_version(args.ip, args.port)
 
     if detected is None:
         version_status = (
-            f"Could not automatically verify the Domoticz version at http://{args.ip}:{args.port}\n"
-            "(server unreachable or response not understood). Please confirm manually,\n"
-            "via Setup > About in Domoticz, that your version is 2025.1 or newer before switching."
+            f"Could not automatically verify the Domoticz version: {error}\n"
+            "Please confirm manually, via Setup > About in Domoticz, that your version\n"
+            "is 2025.1 or newer before switching. If Domoticz runs on a different host/port,\n"
+            "pass --ip/--port."
         )
         requirement_met = None  # unknown
     elif detected >= min_version:

--- a/Tools/plugin-auto-upgrade-v1.sh
+++ b/Tools/plugin-auto-upgrade-v1.sh
@@ -266,10 +266,11 @@ check_stable9_migration_notice() {
       return
     fi
 
-    # Informational only: remind the user that 'stable8' no longer receives
-    # feature updates and that switching to 'stable9' requires running
-    # Tools/plugin-switch-stable9.sh (a deliberate, one-way action).
-    python3 "$NOTICE_SCRIPT" --no-simulate --yes
+    # Display-only, no flags, no stdin expected: remind the user that
+    # 'stable8' no longer receives feature updates and that switching to
+    # 'stable9' requires explicitly running
+    # Tools/plugin-switch-stable9.sh --i-understand on the command line.
+    python3 "$NOTICE_SCRIPT"
 
     rc=$?
     echo "check_stable9_migration.py exited with code $rc"

--- a/Tools/plugin-auto-upgrade-v1.sh
+++ b/Tools/plugin-auto-upgrade-v1.sh
@@ -249,25 +249,30 @@ is_docker() {
     fi
 }
 
-check_python_and_branch() {
+check_stable9_migration_notice() {
     # inside Tools/plugin-auto-upgrade.sh
 
     # Resolve the Tools directory relative to this script
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+    NOTICE_SCRIPT="$SCRIPT_DIR/check_stable9_migration.py"
 
-    # Make sure python3 exists
-    if ! command -v python3 >/dev/null 2>&1; then
-      echo "python3 not found in PATH. Please install Python 3.11+ to switch to stable8."
-      exit 1
+    if [ ! -f "$NOTICE_SCRIPT" ]; then
+        echo "Warning: $NOTICE_SCRIPT not found. Skipping stable9 migration notice."
+        return
     fi
 
-    # Run the check script in interactive (non-auto) mode.
-    # It will print version info and ask confirmation if appropriate.
-    python3 "$SCRIPT_DIR/check_python_and_branch.py" --no-simulate
+    if ! command -v python3 >/dev/null 2>&1; then
+      echo "python3 not found in PATH. Skipping stable9 migration notice."
+      return
+    fi
 
-    # capture the script exit code if you want to act on it:
+    # Informational only: remind the user that 'stable8' no longer receives
+    # feature updates and that switching to 'stable9' requires running
+    # Tools/plugin-switch-stable9.sh (a deliberate, one-way action).
+    python3 "$NOTICE_SCRIPT" --no-simulate --yes
+
     rc=$?
-    echo "check_python_and_branch.py exited with code $rc"
+    echo "check_stable9_migration.py exited with code $rc"
 }
 
 
@@ -275,7 +280,7 @@ check_python_and_branch() {
 PYTHON_VERSION="python${1:-3}"
 PIP_VERSION="python${1:-3}"
 
-check_python_and_branch
+check_stable9_migration_notice
 set_home
 print_env_details
 set_pip_options

--- a/Tools/plugin-auto-upgrade-v2.sh
+++ b/Tools/plugin-auto-upgrade-v2.sh
@@ -187,16 +187,19 @@ print_version_info() {
     echo "Latest git commit: $(git log --pretty=oneline -1 || echo 'N/A')"
 }
 
-check_python_and_branch() {
+check_stable9_migration_notice() {
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-    CHECK_SCRIPT="$SCRIPT_DIR/check_python_and_branch.py"
+    NOTICE_SCRIPT="$SCRIPT_DIR/check_stable9_migration.py"
 
-    if [ -f "$CHECK_SCRIPT" ]; then
-        python3 "$CHECK_SCRIPT" --no-simulate
+    if [ -f "$NOTICE_SCRIPT" ]; then
+        # Informational only: remind the user that 'stable8' no longer receives
+        # feature updates and that switching to 'stable9' requires running
+        # Tools/plugin-switch-stable9.sh (a deliberate, one-way action).
+        python3 "$NOTICE_SCRIPT" --no-simulate --yes
         rc=$?
-        echo "check_python_and_branch.py exited with code $rc"
+        echo "check_stable9_migration.py exited with code $rc"
     else
-        echo "Warning: $CHECK_SCRIPT not found. Skipping Python branch check."
+        echo "Warning: $NOTICE_SCRIPT not found. Skipping stable9 migration notice."
     fi
 }
 
@@ -213,7 +216,7 @@ check_and_upgrade_pip
 update_python_modules
 update_git_config
 print_version_info
-check_python_and_branch
+check_stable9_migration_notice
 
 echo ""
 echo "Plugin upgrade process completed successfully."

--- a/Tools/plugin-auto-upgrade-v2.sh
+++ b/Tools/plugin-auto-upgrade-v2.sh
@@ -192,10 +192,11 @@ check_stable9_migration_notice() {
     NOTICE_SCRIPT="$SCRIPT_DIR/check_stable9_migration.py"
 
     if [ -f "$NOTICE_SCRIPT" ]; then
-        # Informational only: remind the user that 'stable8' no longer receives
-        # feature updates and that switching to 'stable9' requires running
-        # Tools/plugin-switch-stable9.sh (a deliberate, one-way action).
-        python3 "$NOTICE_SCRIPT" --no-simulate --yes
+        # Display-only, no flags, no stdin expected: remind the user that
+        # 'stable8' no longer receives feature updates and that switching to
+        # 'stable9' requires explicitly running
+        # Tools/plugin-switch-stable9.sh --i-understand on the command line.
+        python3 "$NOTICE_SCRIPT"
         rc=$?
         echo "check_stable9_migration.py exited with code $rc"
     else

--- a/Tools/plugin-switch-stable9.sh
+++ b/Tools/plugin-switch-stable9.sh
@@ -3,20 +3,28 @@
 # Switches a Zigbee for Domoticz checkout from 'stable8' to 'stable9'.
 #
 # 'stable9' drops the legacy Domoticz widget model and requires the
-# Domoticz Extended Framework (DomoticzEx). This is a ONE-WAY move: once
-# Domoticz (re)creates devices under the Extended Framework, 'stable8'
-# can no longer manage them. There is no supported path back.
+# Domoticz Extended Framework (DomoticzEx, available since Domoticz
+# 2025.1). This is a ONE-WAY move: once Domoticz (re)creates devices
+# under the Extended Framework, 'stable8' can no longer manage them.
+# There is no supported path back.
+#
+# Usage: plugin-switch-stable9.sh [domoticz_ip] [domoticz_port]
+#   Defaults: 127.0.0.1 8080
 
 set -e
+
+DOMOTICZ_IP="${1:-127.0.0.1}"
+DOMOTICZ_PORT="${2:-8080}"
 
 # Get the directory where the script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$(dirname "$SCRIPT_DIR")"  # Go to parent directory of Tools/
 
-# Require the user to have explicitly acknowledged the one-way notice
-echo "Checking stable9 migration acknowledgement..."
-if ! python3 "$SCRIPT_DIR/check_stable9_migration.py" --no-simulate; then
-    echo "Error: migration not acknowledged. Cannot switch to stable9 branch."
+# Confirm the Domoticz version supports the Extended Framework, and
+# require the user to have explicitly acknowledged the one-way notice
+echo "Checking Domoticz version and stable9 migration acknowledgement..."
+if ! python3 "$SCRIPT_DIR/check_stable9_migration.py" --ip "$DOMOTICZ_IP" --port "$DOMOTICZ_PORT" --no-simulate; then
+    echo "Error: migration not confirmed. Cannot switch to stable9 branch."
     exit 1
 fi
 

--- a/Tools/plugin-switch-stable9.sh
+++ b/Tools/plugin-switch-stable9.sh
@@ -4,18 +4,26 @@
 #
 # 'stable9' drops the legacy Domoticz widget model and requires the
 # Domoticz Extended Framework (DomoticzEx, available since Domoticz
-# 2025.1). This is a ONE-WAY move: once Domoticz (re)creates devices
-# under the Extended Framework, 'stable8' can no longer manage them.
-# There is no supported path back.
+# 2025.1). The switch itself is forward compatible and does not modify
+# or recreate any existing device. The move is forward-only in terms of
+# support: 'stable8' is closed for new development, so going back
+# afterwards is not a supported path.
 #
-# Usage: plugin-switch-stable9.sh [--ip IP] [--port PORT] [-h|--help]
+# Usage: plugin-switch-stable9.sh --i-understand [--ip IP] [--port PORT] [-h|--help]
 #   Defaults: --ip 127.0.0.1 --port 8080
+#
+# Run with no arguments (or without --i-understand) to only display the
+# migration notice and Domoticz version check, without touching git.
+# The actual branch switch only happens when --i-understand is passed
+# explicitly on the command line by a human who read the notice.
 
 set -e
 
 usage() {
-    echo "Usage: $(basename "$0") [--ip IP] [--port PORT]"
+    echo "Usage: $(basename "$0") --i-understand [--ip IP] [--port PORT]"
     echo
+    echo "  --i-understand Required to actually perform the switch. Without it,"
+    echo "                 only the migration notice and version check are shown."
     echo "  --ip IP        Domoticz server IP/host (default: 127.0.0.1)"
     echo "  --port PORT    Domoticz web server port (default: 8080)"
     echo "  -h, --help     Show this help and exit"
@@ -23,9 +31,14 @@ usage() {
 
 DOMOTICZ_IP="127.0.0.1"
 DOMOTICZ_PORT="8080"
+I_UNDERSTAND=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
+        --i-understand)
+            I_UNDERSTAND=true
+            shift
+            ;;
         --ip)
             DOMOTICZ_IP="$2"
             shift 2
@@ -50,12 +63,22 @@ done
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$(dirname "$SCRIPT_DIR")"  # Go to parent directory of Tools/
 
-# Confirm the Domoticz version supports the Extended Framework, and
-# require the user to have explicitly acknowledged the one-way notice
-echo "Checking Domoticz version and stable9 migration acknowledgement..."
-if ! python3 "$SCRIPT_DIR/check_stable9_migration.py" --ip "$DOMOTICZ_IP" --port "$DOMOTICZ_PORT" --no-simulate; then
-    echo "Error: migration not confirmed. Cannot switch to stable9 branch."
+# Always show the notice and confirm the Domoticz version supports the
+# Extended Framework. Without --i-understand this is display-only and
+# the script stops here without touching git.
+CHECK_ARGS=(--ip "$DOMOTICZ_IP" --port "$DOMOTICZ_PORT")
+if [ "$I_UNDERSTAND" = true ]; then
+    CHECK_ARGS+=(--i-understand)
+fi
+
+echo "Checking Domoticz version and stable9 migration notice..."
+if ! python3 "$SCRIPT_DIR/check_stable9_migration.py" "${CHECK_ARGS[@]}"; then
+    echo "Error: Domoticz version requirement not met. Cannot switch to stable9 branch."
     exit 1
+fi
+
+if [ "$I_UNDERSTAND" != true ]; then
+    exit 0
 fi
 
 # Store current directory
@@ -102,8 +125,8 @@ if git show-ref --verify --quiet refs/remotes/origin/stable9; then
     }
 
     echo "Successfully switched to stable9 branch"
-    echo "Reminder: this is a one-way move. Do not attempt to revert to stable8"
-    echo "on this installation once Domoticz has (re)created your devices."
+    echo "Reminder: 'stable8' is closed for new development, so going back to it"
+    echo "afterwards is not a supported path. Your devices were not modified by this switch."
 else
     echo "Error: stable9 branch does not exist in the remote repository"
     exit 1

--- a/Tools/plugin-switch-stable9.sh
+++ b/Tools/plugin-switch-stable9.sh
@@ -8,13 +8,43 @@
 # under the Extended Framework, 'stable8' can no longer manage them.
 # There is no supported path back.
 #
-# Usage: plugin-switch-stable9.sh [domoticz_ip] [domoticz_port]
-#   Defaults: 127.0.0.1 8080
+# Usage: plugin-switch-stable9.sh [--ip IP] [--port PORT] [-h|--help]
+#   Defaults: --ip 127.0.0.1 --port 8080
 
 set -e
 
-DOMOTICZ_IP="${1:-127.0.0.1}"
-DOMOTICZ_PORT="${2:-8080}"
+usage() {
+    echo "Usage: $(basename "$0") [--ip IP] [--port PORT]"
+    echo
+    echo "  --ip IP        Domoticz server IP/host (default: 127.0.0.1)"
+    echo "  --port PORT    Domoticz web server port (default: 8080)"
+    echo "  -h, --help     Show this help and exit"
+}
+
+DOMOTICZ_IP="127.0.0.1"
+DOMOTICZ_PORT="8080"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ip)
+            DOMOTICZ_IP="$2"
+            shift 2
+            ;;
+        --port)
+            DOMOTICZ_PORT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
 
 # Get the directory where the script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/Tools/plugin-switch-stable9.sh
+++ b/Tools/plugin-switch-stable9.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Switches a Zigbee for Domoticz checkout from 'stable8' to 'stable9'.
+#
+# 'stable9' drops the legacy Domoticz widget model and requires the
+# Domoticz Extended Framework (DomoticzEx). This is a ONE-WAY move: once
+# Domoticz (re)creates devices under the Extended Framework, 'stable8'
+# can no longer manage them. There is no supported path back.
+
+set -e
+
+# Get the directory where the script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$(dirname "$SCRIPT_DIR")"  # Go to parent directory of Tools/
+
+# Require the user to have explicitly acknowledged the one-way notice
+echo "Checking stable9 migration acknowledgement..."
+if ! python3 "$SCRIPT_DIR/check_stable9_migration.py" --no-simulate; then
+    echo "Error: migration not acknowledged. Cannot switch to stable9 branch."
+    exit 1
+fi
+
+# Store current directory
+CURRENT_DIR=$(pwd)
+
+# Check if we are in a git repository
+if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    echo "Error: Not in a git repository"
+    exit 1
+fi
+
+# Check for uncommitted changes
+if ! git diff --quiet HEAD; then
+    echo "Error: You have uncommitted changes. Please commit or stash them first."
+    exit 1
+fi
+
+# Fetch latest changes
+echo "Fetching latest changes..."
+git fetch origin || {
+    echo "Error: Failed to fetch from remote"
+    exit 1
+}
+
+# Pull latest changes in current branch
+echo "Pulling latest changes in current branch..."
+git pull || {
+    echo "Error: Failed to pull latest changes"
+    exit 1
+}
+
+# Switch to stable9 branch
+echo "Switching to stable9 branch..."
+if git show-ref --verify --quiet refs/remotes/origin/stable9; then
+    git checkout stable9 || {
+        echo "Error: Failed to switch to stable9 branch"
+        exit 1
+    }
+
+    # Pull latest changes in stable9
+    git pull origin stable9 || {
+        echo "Error: Failed to pull latest changes in stable9"
+        exit 1
+    }
+
+    echo "Successfully switched to stable9 branch"
+    echo "Reminder: this is a one-way move. Do not attempt to revert to stable8"
+    echo "on this installation once Domoticz has (re)created your devices."
+else
+    echo "Error: stable9 branch does not exist in the remote repository"
+    exit 1
+fi
+
+# Return to original directory
+cd "$CURRENT_DIR"
+
+echo "Branch switch completed successfully"

--- a/Tools/plugin-switch-stable9.sh
+++ b/Tools/plugin-switch-stable9.sh
@@ -5,9 +5,10 @@
 # 'stable9' drops the legacy Domoticz widget model and requires the
 # Domoticz Extended Framework (DomoticzEx, available since Domoticz
 # 2025.1). The switch itself is forward compatible and does not modify
-# or recreate any existing device. The move is forward-only in terms of
-# support: 'stable8' is closed for new development, so going back
-# afterwards is not a supported path.
+# or recreate any existing device. But any device paired AFTER switching
+# is created directly under the Extended Framework, and such new devices
+# are not compatible with 'stable8's legacy widget model — going back
+# stops being an option as soon as a new device is added.
 #
 # Usage: plugin-switch-stable9.sh --i-understand [--ip IP] [--port PORT] [-h|--help]
 #   Defaults: --ip 127.0.0.1 --port 8080
@@ -125,8 +126,10 @@ if git show-ref --verify --quiet refs/remotes/origin/stable9; then
     }
 
     echo "Successfully switched to stable9 branch"
-    echo "Reminder: 'stable8' is closed for new development, so going back to it"
-    echo "afterwards is not a supported path. Your devices were not modified by this switch."
+    echo "Your existing devices were not modified by this switch. Reminder: any device"
+    echo "you pair from now on is created under the Extended Framework and will not be"
+    echo "usable if you go back to 'stable8' — going back stops being an option as soon"
+    echo "as a new device is added."
 else
     echo "Error: stable9 branch does not exist in the remote repository"
     exit 1

--- a/plugin.py
+++ b/plugin.py
@@ -359,6 +359,13 @@ class BasePlugin:
 
         Domoticz.Status( "Welcome to Zigbee for Domoticz (Z4D) plugin. (c)pipiche38 - 2018 - 2025")
 
+        Domoticz.Error("************* IMPORTANT *************")
+        Domoticz.Error("The 'stable8' branch no longer receives new features, only critical fixes.")
+        Domoticz.Error("New development continues on 'stable9', built on the Domoticz Extended Framework.")
+        Domoticz.Error("To get further updates, run: Tools/plugin-switch-stable9.sh")
+        Domoticz.Error("This is a ONE-WAY move: there is no supported path back to 'stable8' afterwards.")
+        Domoticz.Error("************* IMPORTANT *************")
+
         # Print PYTHONPATH if set
         pythonpath = os.getenv('PYTHONPATH')
         if pythonpath:

--- a/plugin.py
+++ b/plugin.py
@@ -363,7 +363,7 @@ class BasePlugin:
         Domoticz.Error("The 'stable8' branch no longer receives new features, only critical fixes.")
         Domoticz.Error("New development continues on 'stable9', built on the Domoticz Extended Framework.")
         Domoticz.Error("To get further updates, run on the command line: Tools/plugin-switch-stable9.sh --i-understand")
-        Domoticz.Error("'stable8' is closed for new development: going back afterwards is not a supported path.")
+        Domoticz.Error("Any device paired after switching is created under the Extended Framework and is not usable back on 'stable8'.")
         Domoticz.Error("************* IMPORTANT *************")
 
         # Print PYTHONPATH if set

--- a/plugin.py
+++ b/plugin.py
@@ -362,8 +362,8 @@ class BasePlugin:
         Domoticz.Error("************* IMPORTANT *************")
         Domoticz.Error("The 'stable8' branch no longer receives new features, only critical fixes.")
         Domoticz.Error("New development continues on 'stable9', built on the Domoticz Extended Framework.")
-        Domoticz.Error("To get further updates, run: Tools/plugin-switch-stable9.sh")
-        Domoticz.Error("This is a ONE-WAY move: there is no supported path back to 'stable8' afterwards.")
+        Domoticz.Error("To get further updates, run on the command line: Tools/plugin-switch-stable9.sh --i-understand")
+        Domoticz.Error("'stable8' is closed for new development: going back afterwards is not a supported path.")
         Domoticz.Error("************* IMPORTANT *************")
 
         # Print PYTHONPATH if set


### PR DESCRIPTION
stable9 will require the Domoticz Extended Framework (DomoticzEx) and drops the legacy widget model, so a stable8 install cannot be seamlessly upgraded in place. 
Add Tools/check_stable9_migration.py and Tools/plugin-switch-stable9.sh (modeled on the earlier plugin-switch-stable8.sh precedent) to explicitly warn users and require acknowledgement before switching branches, since the move is one-way. Wire the notice into the existing upgrade scripts and surface it once at plugin startup and on WebUI-triggered upgrade, replacing the now-dead stable7-era check_python_and_branch.py hook.

