### PR TITLE
Fix TypeError: 'float' object cannot be interpreted as an integer on PowerFactor/FanSpeed widget updates (#2003)

### DIFF
--- a/Modules/domoMaj.py
+++ b/Modules/domoMaj.py
@@ -219,9 +219,8 @@ def _domo_maj_one_cluster_type_entry( self, Devices, NwkId, Ep, device_id_ieee, 
         self.log.logging(["Widget", "Electric"], "Debug", "PowerFactor %s WidgetType: %s Value: %s (%s)" % (
             NwkId, WidgetType, value, type(value)), NwkId)
 
-        nValue = round(value, 1)
-        sValue = str(nValue)
-        update_domoticz_widget(self, Devices, device_id_ieee, device_unit, nValue, sValue, BatteryLevel, SignalLevel)
+        sValue = str(round(value, 1))
+        update_domoticz_widget(self, Devices, device_id_ieee, device_unit, 0, sValue, BatteryLevel, SignalLevel)
 
     if "Power" in ClusterType:  # Instant Power/Watts
         # Power and Meter usage are triggered only with the Instant Power usage.

--- a/Modules/domoMaj.py
+++ b/Modules/domoMaj.py
@@ -795,9 +795,8 @@ def _domo_maj_one_cluster_type_entry( self, Devices, NwkId, Ep, device_id_ieee, 
         update_domoticz_widget(self, Devices, device_id_ieee, device_unit, nValue, sValue, BatteryLevel, SignalLevel)
 
     if Attribute_ == "0007" and ClusterType == "FanControl" and WidgetType == "FanSpeed":
-        nValue = round(value, 1)
-        sValue = str(nValue)
-        update_domoticz_widget(self, Devices, device_id_ieee, device_unit, nValue, sValue, BatteryLevel, SignalLevel)
+        sValue = str(round(value, 1))
+        update_domoticz_widget(self, Devices, device_id_ieee, device_unit, 0, sValue, BatteryLevel, SignalLevel)
 
     if Attribute_ == "0001" and WidgetType == "OutDoorTemperature" and "OutDoorTemperature" in ClusterType:
         nValue = value

--- a/Modules/domoticzAbstractLayer.py
+++ b/Modules/domoticzAbstractLayer.py
@@ -594,7 +594,7 @@ def domo_update_api(self, Devices, DeviceID_, Unit_, nValue, sValue,
         return
 
     unit_obj = Devices[DeviceID_].Units[Unit_]
-    unit_obj.nValue = nValue
+    unit_obj.nValue = int(nValue)
     unit_obj.sValue = sValue
 
     # TimedOut lives on the Device, not the Unit

--- a/Modules/input.py
+++ b/Modules/input.py
@@ -28,6 +28,8 @@ All decoder calls are wrapped in a ``try/except`` block so that a single
 malformed message never takes down the whole receive loop.
 """
 
+import traceback
+
 from Z4D_decoders.z4d_decoder_Active_Ep_Rsp import Decode8045
 from Z4D_decoders.z4d_decoder_Attr_Discovery_Rsp import Decode8140
 from Z4D_decoders.z4d_decoder_bindings import Decode8030, Decode8031
@@ -281,5 +283,5 @@ def _decode_message(self, MsgType, Devices, Data, MsgData, MsgLQI):
         self.log.logging(
             "Input", "Error",
             f"_decode_message - unhandled exception while processing "
-            f"MsgType {MsgType}: {exc}",
+            f"MsgType {MsgType}: {exc}\n{traceback.format_exc()}",
         )


### PR DESCRIPTION
##  Summary
  - Modules/input.py: _decode_message's except block only logged str(exc), discarding the real traceback (the auto-attached "StackTrace" is the logging  call site, not the exception's origin — see LoggingManagement.py). Added traceback.format_exc() so future unhandled exceptions in this path are  actually debuggable. This is what let us pinpoint the root cause below.
  - Modules/domoMaj.py: PowerFactor and FanSpeed widgets both computed nValue = round(value, 1), which returns a float. Every other widget of the same  Domoticz type/subtype (243/6, "Percentage") in this file passes nValue=0 and puts the number in sValue; brought both in line with that convention.
  - Modules/domoticzAbstractLayer.py: domo_update_api assigned nValue straight to unit_obj.nValue — the exact point where Domoticz's native API raises  this TypeError on a float. Added int(nValue) there as a boundary guard so any future caller with the same mistake fails safe instead of crashing.

##  Root cause
  Tuya TS0601 power-factor (and fan-speed) reports triggered round(value, 1) on every message, crashing the widget update every ~40s. Confirmed via a  diagnostic branch that added the traceback logging, then reading the resulting errors.json trace back to domoMaj.py:222 / domoTools.py /  domoticzAbstractLayer.py:597.

##  Test plan
  - [x] pytest . — 1290 passed
  - [x] python -c "import ast; ast.parse(...)" on all changed files
  - [ ] Manual verification against real Tuya TS0601 power-factor/fan-speed device (waiting for @waltervl feedback/test)

  Fixes #2003