### PR TITLE
Fix TypeError at ZNP startup building 0x8010 firmware version frame

### DIFF
--- a/Classes/ZigpyTransport/firmwareversionHelper.py
+++ b/Classes/ZigpyTransport/firmwareversionHelper.py
@@ -81,11 +81,11 @@ def znp_extract_versioning_for_plugin(self, znp_model, znp_manuf, version):
     # It is assumed that the build is always on the right side in version
     build = (''.join(char for char in reversed(version) if char.isdigit()))[::-1]
     if "Z-Stack Home" in version:
-        firmware_branch = firmware_major_version = 22
+        firmware_branch = firmware_major_version = "22"
         firmware_version = "Z-Stack Home " + "(build %s)" %build
-        
+
     elif "Z-Stack 3.0.x" in version:
-        firmware_branch = firmware_major_version = 21
+        firmware_branch = firmware_major_version = "21"
         firmware_version = "Z-Stack 3.0.x " + "(build %s)" %build
 
     else:

--- a/Classes/ZigpyTransport/plugin_encoders.py
+++ b/Classes/ZigpyTransport/plugin_encoders.py
@@ -100,7 +100,7 @@ def build_plugin_8009_frame_content(self, radiomodule):
 
 
 def build_plugin_8010_frame_content(Branch, Major, Version, full_version):
-    return encapsulate_plugin_frame("8010", Branch + Major + Version + full_version, "00")
+    return encapsulate_plugin_frame("8010", f"{Branch}{Major}{Version}{full_version}", "00")
 
 
 def build_plugin_8011_frame_content(self, nwkid, cluster, sequence, status, lqi):

--- a/tests/ZigpyTransport/test_plugin_encoders_firmware.py
+++ b/tests/ZigpyTransport/test_plugin_encoders_firmware.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for the 0x8010 (firmware version) frame pipeline:
+
+  - Classes/ZigpyTransport/firmwareversionHelper.py
+      bellows_extract_versioning_for_plugin
+      blz_extract_versioning_for_plugin
+      deconz_extract_versioning_for_plugin
+      znp_extract_versioning_for_plugin
+  - Classes/ZigpyTransport/plugin_encoders.py
+      build_plugin_8010_frame_content
+
+Regression coverage for the startup crash reported against a CC2531
+("Z-Stack Home" firmware): znp_extract_versioning_for_plugin returned an
+int for firmware_branch/firmware_major_version on two branches, and
+build_plugin_8010_frame_content concatenated Branch/Major/Version/
+full_version with `+`, raising
+    TypeError: unsupported operand type(s) for +: 'int' and 'str'
+
+Every *_extract_versioning_for_plugin() must always return str for
+Branch/Major/Version, and build_plugin_8010_frame_content() must be
+robust even if a caller ever passes a non-str value again.
+
+Imports of the SUT are done inside each test (not at module level) so the
+session-scoped zigpy/radio stub fixture in conftest.py installs first.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+# Claim the real module during collection: the root tests/conftest.py installs
+# a stub for Modules.zigbeeVersionTable (without ZNP_MODEL) for decoder tests
+# that don't need the real table. sys.modules.setdefault() in that fixture
+# means whichever import happens first wins, so import it for real here.
+import Modules.zigbeeVersionTable  # noqa: F401
+
+
+def make_self():
+    m = MagicMock()
+    m.log = MagicMock()
+    m.log.logging = MagicMock()
+    return m
+
+
+class TestBuildPlugin8010FrameContent(unittest.TestCase):
+    """encapsulate_plugin_frame boundary: must never raise on mixed types."""
+
+    def test_all_strings(self):
+        from Classes.ZigpyTransport.plugin_encoders import build_plugin_8010_frame_content
+
+        frame = build_plugin_8010_frame_content("21", "000000", "0297", "")
+        # 01 + 8010 + length(4) + ff + payload + lqi(00) + 03
+        payload = "21" + "000000" + "0297" + ""
+        expected = "01" + "8010" + ("%04x" % len(payload)) + "ff" + payload + "00" + "03"
+        self.assertEqual(frame, expected)
+
+    def test_int_branch_does_not_raise(self):
+        from Classes.ZigpyTransport.plugin_encoders import build_plugin_8010_frame_content
+
+        # Regression: firmware_branch used to be returned as int on some
+        # znp code paths, crashing this concatenation at startup.
+        frame = build_plugin_8010_frame_content(22, "000000", "Z-Stack Home (build 20210708)", "")
+        self.assertIn("22", frame)
+
+    def test_int_major_and_version_do_not_raise(self):
+        from Classes.ZigpyTransport.plugin_encoders import build_plugin_8010_frame_content
+
+        frame = build_plugin_8010_frame_content("21", 0, 297, "")
+        self.assertIn("210297", frame)
+
+    def test_none_full_version_does_not_raise(self):
+        from Classes.ZigpyTransport.plugin_encoders import build_plugin_8010_frame_content
+
+        frame = build_plugin_8010_frame_content("21", "00", "0297", None)
+        self.assertTrue(frame.startswith("018010"))
+        self.assertIn("None", frame)
+
+
+class TestZnpExtractVersioning(unittest.TestCase):
+    """All three branches must return str for branch/major_version."""
+
+    def test_zstack_home_branch(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import znp_extract_versioning_for_plugin
+
+        branch, version, build = znp_extract_versioning_for_plugin(
+            make_self(), "CC2531", "Texas Instruments", "Z-Stack Home 1.2.2a 20210708"
+        )
+        self.assertIsInstance(branch, str)
+        self.assertEqual(branch, "22")
+        self.assertIsInstance(version, str)
+        self.assertIsInstance(build, str)
+
+    def test_zstack_3_0_x_branch(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import znp_extract_versioning_for_plugin
+
+        branch, version, build = znp_extract_versioning_for_plugin(
+            make_self(), "CC2531", "Texas Instruments", "Z-Stack 3.0.x 20210708"
+        )
+        self.assertIsInstance(branch, str)
+        self.assertEqual(branch, "21")
+        self.assertIsInstance(version, str)
+        self.assertIsInstance(build, str)
+
+    def test_zstack_3_30_plus_branch_uses_znp_model_table(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import znp_extract_versioning_for_plugin
+
+        branch, version, build = znp_extract_versioning_for_plugin(
+            make_self(), "CC2652", "Texas Instruments", "Z-Stack 20210708"
+        )
+        self.assertIsInstance(branch, str)
+        self.assertEqual(branch, "20")  # ZNP_MODEL["CC2652"]
+        self.assertIsInstance(version, str)
+        self.assertIsInstance(build, str)
+
+    def test_znp_result_feeds_build_plugin_8010_without_raising(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import znp_extract_versioning_for_plugin
+        from Classes.ZigpyTransport.plugin_encoders import build_plugin_8010_frame_content
+
+        self_mock = make_self()
+        for model, version in (
+            ("CC2531", "Z-Stack Home 1.2.2a 20210708"),
+            ("CC2531", "Z-Stack 3.0.x 20210708"),
+            ("CC2652", "Z-Stack 20210708"),
+        ):
+            branch, firmware_version, build = znp_extract_versioning_for_plugin(
+                self_mock, model, "Texas Instruments", version
+            )
+            # Mirrors AppZnp.py's actual call
+            frame = build_plugin_8010_frame_content(branch, "000000", firmware_version, "")
+            self.assertTrue(frame.startswith("018010"))
+
+
+class TestBellowsExtractVersioning(unittest.TestCase):
+    def test_returns_all_strings(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import bellows_extract_versioning_for_plugin
+
+        branch, major, version = bellows_extract_versioning_for_plugin(
+            make_self(), "Silicon Labs", "Some Board", "6.10.3.0 build 297"
+        )
+        self.assertIsInstance(branch, str)
+        self.assertIsInstance(major, str)
+        self.assertIsInstance(version, str)
+
+    def test_known_board_branches(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import bellows_extract_versioning_for_plugin
+
+        self_mock = make_self()
+        branch, _, _ = bellows_extract_versioning_for_plugin(self_mock, "Elelabs", "ELU01x", "6.10.3.0 build 297")
+        self.assertEqual(branch, "31")
+
+        branch, _, _ = bellows_extract_versioning_for_plugin(self_mock, "Elelabs", "ELR02x", "6.10.3.0 build 297")
+        self.assertEqual(branch, "30")
+
+        branch, _, _ = bellows_extract_versioning_for_plugin(self_mock, None, "ZBDongle-E", "6.10.3.0 build 297")
+        self.assertEqual(branch, "32")
+
+        branch, _, _ = bellows_extract_versioning_for_plugin(self_mock, None, "Dongle Plus MG24", "6.10.3.0 build 297")
+        self.assertEqual(branch, "33")
+
+        branch, _, _ = bellows_extract_versioning_for_plugin(self_mock, None, "Unknown Board", "6.10.3.0 build 297")
+        self.assertEqual(branch, "98")
+
+    def test_bellows_result_feeds_build_plugin_8010_without_raising(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import bellows_extract_versioning_for_plugin
+        from Classes.ZigpyTransport.plugin_encoders import build_plugin_8010_frame_content
+
+        branch, major, version = bellows_extract_versioning_for_plugin(
+            make_self(), "Elelabs", "ELU01x", "6.10.3.0 build 297"
+        )
+        # Mirrors AppBellows.py's actual call
+        frame = build_plugin_8010_frame_content(branch, major, version, "6.10.3.0 build 297")
+        self.assertTrue(frame.startswith("018010"))
+
+
+class TestDeconzExtractVersioning(unittest.TestCase):
+    def test_returns_strings_for_known_model(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import deconz_extract_versioning_for_plugin
+
+        branch, version = deconz_extract_versioning_for_plugin(make_self(), "ConBee II", "dresden elektronik", 0x26580700)
+        self.assertIsInstance(branch, str)
+        self.assertEqual(branch, "40")
+        self.assertIsInstance(version, str)
+
+    def test_unknown_model_defaults_to_97(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import deconz_extract_versioning_for_plugin
+
+        branch, _ = deconz_extract_versioning_for_plugin(make_self(), "Some Unknown Stick", "dresden elektronik", 0x1)
+        self.assertEqual(branch, "97")
+
+    def test_deconz_result_feeds_build_plugin_8010_without_raising(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import deconz_extract_versioning_for_plugin
+        from Classes.ZigpyTransport.plugin_encoders import build_plugin_8010_frame_content
+
+        branch, version = deconz_extract_versioning_for_plugin(make_self(), "RaspBee", "dresden elektronik", 0x12345678)
+        # Mirrors AppDeconz.py's actual call
+        frame = build_plugin_8010_frame_content(branch, "00", "0000", version)
+        self.assertTrue(frame.startswith("018010"))
+
+
+class TestBlzExtractVersioning(unittest.TestCase):
+    def test_returns_expected_branch(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import blz_extract_versioning_for_plugin
+
+        branch, version = blz_extract_versioning_for_plugin(make_self(), "model", "manuf", "1.0.0")
+        self.assertEqual(branch, "50")
+        self.assertEqual(version, "1.0.0")
+
+    def test_blz_result_feeds_build_plugin_8010_without_raising_even_with_int_version(self):
+        from Classes.ZigpyTransport.firmwareversionHelper import blz_extract_versioning_for_plugin
+        from Classes.ZigpyTransport.plugin_encoders import build_plugin_8010_frame_content
+
+        # Defensive: even if a future caller passes a non-str version,
+        # build_plugin_8010_frame_content must not raise.
+        branch, version = blz_extract_versioning_for_plugin(make_self(), "model", "manuf", 100)
+        frame = build_plugin_8010_frame_content(branch, "00", "0000", version)
+        self.assertTrue(frame.startswith("018010"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

  - `znp_extract_versioning_for_plugin()` returned `firmware_branch`/`firmware_major_version` as an **int** (`22`/`21`) on the "Z-Stack Home" and  "Z-Stack 3.0.x" code paths, unlike the `ZNP_MODEL` table lookup and every other radio backend (bellows, deconz, blz), which always return `str`.
  - `build_plugin_8010_frame_content()` concatenates `Branch + Major + Version + full_version` with `+`, so an int `Branch` crashed plugin startup for  CC2531 boards reporting "Z-Stack Home" firmware:  TypeError: unsupported operand type(s) for +: 'int' and 'str'
  - Fixed the root cause (string literals in `firmwareversionHelper.py`) and hardened `build_plugin_8010_frame_content()` itself to coerce its  arguments via an f-string, consistent with the existing pattern of coercing types at the Domoticz/plugin API boundary (see the recent  FanSpeed/PowerFactor nValue fixes), so a similar bug in a future caller can't crash startup again.

  ## Test plan

  - [x] Added `tests/ZigpyTransport/test_plugin_encoders_firmware.py` covering all four `*_extract_versioning_for_plugin()` helpers  (bellows/blz/deconz/znp) asserting Branch/Major/Version are always `str`, plus`build_plugin_8010_frame_content()` with mixed int/None/str inputs and  end-to-end per-backend scenarios mirroring the real `AppZnp`/`AppBellows`/`AppDeconz`/`AppBlz` call sites.
  - [x] `pytest tests/` — 1306 passed.
  - [x] `flake8` (CI subset E9,F63,F7,F82) clean on the new test file.