### PR TITLE
Fix infinite Configure Reporting mismatch loop (#1999)

### DIFF
--- a/Classes/ConfigureReporting.py
+++ b/Classes/ConfigureReporting.py
@@ -45,10 +45,9 @@ CONFIGURE_REPORT_PERFORM_TIME = 21  # Reenforce will be done each xx hours
 
 # A device that acknowledges (Status 00) a Configure Reporting but then keeps reporting back
 # a different Min/Max/Change (firmware silently clamps or ignores the request) must not be
-# re-configured (and potentially re-bound) forever, once per heartbeat. Cap the number of
-# consecutive attempts and back off for a while before trying again.
-MAX_CFG_RPT_MISMATCH_RETRY = 3
-CFG_RPT_MISMATCH_BACKOFF = CONFIGURE_REPORT_PERFORM_TIME * 3600  # seconds
+# re-configured (and potentially re-bound) forever, once per heartbeat. Give up permanently
+# (until the next plugin restart, see reset_mismatch_retry_datastruct) after this many attempts.
+MAX_CFG_RPT_MISMATCH_RETRY = 2
 
 
 def get_max_cfg_rpt_attribute_value( self, nwkid=None):
@@ -528,29 +527,25 @@ class ConfigureReporting:
 
 def _allow_configure_reporting_retry(self, Nwkid, Ep, cluster):
     # Gate the "misconfigured reporting" Configure Reporting re-send: after
-    # MAX_CFG_RPT_MISMATCH_RETRY consecutive attempts, back off for CFG_RPT_MISMATCH_BACKOFF
-    # seconds instead of re-sending (and possibly re-binding) on every heartbeat forever.
+    # MAX_CFG_RPT_MISMATCH_RETRY consecutive attempts, give up for good (no more
+    # re-sends, no more re-binds) until the next plugin restart clears the counter
+    # via reset_mismatch_retry_datastruct(), or the device reports back a matching
+    # configuration via _clear_configure_reporting_retry().
     check_datastruct(self, STORE_CONFIGURE_REPORTING, Nwkid, Ep, cluster)
     retry = self.ListOfDevices[Nwkid][STORE_CONFIGURE_REPORTING]["Ep"][Ep][cluster].setdefault(
-        "MismatchRetry", {"Count": 0, "TimeStamp": 0, "Reported": False}
+        "MismatchRetry", {"Count": 0, "Reported": False}
     )
 
-    now = time.time()
     if retry["Count"] >= MAX_CFG_RPT_MISMATCH_RETRY:
-        if now < retry["TimeStamp"] + CFG_RPT_MISMATCH_BACKOFF:
-            return False
-        # Backoff window elapsed, give the device another round of attempts
-        retry["Count"] = 0
-        retry["Reported"] = False
+        return False
 
     retry["Count"] += 1
-    retry["TimeStamp"] = now
 
     if retry["Count"] >= MAX_CFG_RPT_MISMATCH_RETRY and not retry["Reported"]:
         self.logging(
             "Status",
             f"------ Z4D giving up on Configure Reporting for {Nwkid}/{Ep}/{cluster} after {MAX_CFG_RPT_MISMATCH_RETRY} attempts; "
-            f"device does not seem to honor the requested reporting configuration. Will retry in {CFG_RPT_MISMATCH_BACKOFF // 3600}h",
+            f"device does not seem to honor the requested reporting configuration. Will retry after the next plugin restart",
             nwkid=Nwkid,
         )
         retry["Reported"] = True

--- a/Classes/ConfigureReporting.py
+++ b/Classes/ConfigureReporting.py
@@ -26,8 +26,9 @@ from Modules.bindings import bindDevice, unbindDevice
 from Modules.pluginDbAttributes import (STORE_CONFIGURE_REPORTING,
                                         STORE_CUSTOM_CONFIGURE_REPORTING,
                                         STORE_READ_CONFIGURE_REPORTING)
-from Modules.tools import (deviceconf_device, get_device_config_param,
-                           get_isqn_datastruct, get_list_isqn_attr_datastruct,
+from Modules.tools import (check_datastruct, deviceconf_device,
+                           get_device_config_param, get_isqn_datastruct,
+                           get_list_isqn_attr_datastruct,
                            get_list_isqn_int_attr_datastruct,
                            getClusterListforEP, is_ack_tobe_disabled,
                            is_attr_unvalid_datastruct, is_bind_ep, is_fake_ep,
@@ -41,6 +42,13 @@ from Zigbee.zclCommands import (zcl_configure_reporting_requestv2,
                                 zcl_read_report_config_request)
 
 CONFIGURE_REPORT_PERFORM_TIME = 21  # Reenforce will be done each xx hours
+
+# A device that acknowledges (Status 00) a Configure Reporting but then keeps reporting back
+# a different Min/Max/Change (firmware silently clamps or ignores the request) must not be
+# re-configured (and potentially re-bound) forever, once per heartbeat. Cap the number of
+# consecutive attempts and back off for a while before trying again.
+MAX_CFG_RPT_MISMATCH_RETRY = 3
+CFG_RPT_MISMATCH_BACKOFF = CONFIGURE_REPORT_PERFORM_TIME * 3600  # seconds
 
 
 def get_max_cfg_rpt_attribute_value( self, nwkid=None):
@@ -486,19 +494,23 @@ class ConfigureReporting:
 
                         if x == "Change" and not analog_value(int(attribute_current_configuration['DataType'], 16)):
                             continue
-                        
+
                         if attribute_current_configuration[x] == '' or cluster_configuration[attribut][x] == '':
                             # We don't have a value for this attribute, so we cannot compare
                             continue
 
                         if int(attribute_current_configuration[x],16) == int(cluster_configuration[attribut][x],16):
                             continue
-                        
-                        if not wip_flap:
-                            self.logging("Status", f"------ Z4D detects misconfigured reporting for device {Nwkid} on ep {_ep} and cluster {_cluster}", nwkid=Nwkid)
-                        
-                        self.logging("Status", f" - Attribute {attribut} forces a Configure Reporting due to field {x} '{attribute_current_configuration[ x ]}' != '{cluster_configuration[ attribut ][ x]}'", nwkid=Nwkid)
-                        configure_reporting_for_one_cluster(self, Nwkid, _ep, _cluster, True, cluster_configuration)
+
+                        if _allow_configure_reporting_retry(self, Nwkid, _ep, _cluster):
+                            if not wip_flap:
+                                self.logging("Status", f"------ Z4D detects misconfigured reporting for device {Nwkid} on ep {_ep} and cluster {_cluster}", nwkid=Nwkid)
+
+                            self.logging("Status", f" - Attribute {attribut} forces a Configure Reporting due to field {x} '{attribute_current_configuration[ x ]}' != '{cluster_configuration[ attribut ][ x]}'", nwkid=Nwkid)
+                            configure_reporting_for_one_cluster(self, Nwkid, _ep, _cluster, True, cluster_configuration)
+                        else:
+                            self.logging("Debug", f"------ check_and_redo_configure_reporting_if_needed - {Nwkid} {_ep} {_cluster} {attribut} still mismatched on {x}, backing off after repeated failed attempts", nwkid=Nwkid)
+
                         wip_flap = True
                         cluster_update = True
                         break   # No need to check for an other difference
@@ -507,9 +519,55 @@ class ConfigureReporting:
                         # We need to move to the next cluster, as we have requested
                         # a cluster cfg reporting update
                         break
+                else:
+                    # Every attribute of this cluster matched the desired configuration: clear any backoff state
+                    _clear_configure_reporting_retry(self, Nwkid, _ep, _cluster)
         return wip_flap
-           
+
 ####
+
+def _allow_configure_reporting_retry(self, Nwkid, Ep, cluster):
+    # Gate the "misconfigured reporting" Configure Reporting re-send: after
+    # MAX_CFG_RPT_MISMATCH_RETRY consecutive attempts, back off for CFG_RPT_MISMATCH_BACKOFF
+    # seconds instead of re-sending (and possibly re-binding) on every heartbeat forever.
+    check_datastruct(self, STORE_CONFIGURE_REPORTING, Nwkid, Ep, cluster)
+    retry = self.ListOfDevices[Nwkid][STORE_CONFIGURE_REPORTING]["Ep"][Ep][cluster].setdefault(
+        "MismatchRetry", {"Count": 0, "TimeStamp": 0, "Reported": False}
+    )
+
+    now = time.time()
+    if retry["Count"] >= MAX_CFG_RPT_MISMATCH_RETRY:
+        if now < retry["TimeStamp"] + CFG_RPT_MISMATCH_BACKOFF:
+            return False
+        # Backoff window elapsed, give the device another round of attempts
+        retry["Count"] = 0
+        retry["Reported"] = False
+
+    retry["Count"] += 1
+    retry["TimeStamp"] = now
+
+    if retry["Count"] >= MAX_CFG_RPT_MISMATCH_RETRY and not retry["Reported"]:
+        self.logging(
+            "Status",
+            f"------ Z4D giving up on Configure Reporting for {Nwkid}/{Ep}/{cluster} after {MAX_CFG_RPT_MISMATCH_RETRY} attempts; "
+            f"device does not seem to honor the requested reporting configuration. Will retry in {CFG_RPT_MISMATCH_BACKOFF // 3600}h",
+            nwkid=Nwkid,
+        )
+        retry["Reported"] = True
+
+    return True
+
+
+def _clear_configure_reporting_retry(self, Nwkid, Ep, cluster):
+    if (
+        Nwkid in self.ListOfDevices
+        and STORE_CONFIGURE_REPORTING in self.ListOfDevices[Nwkid]
+        and "Ep" in self.ListOfDevices[Nwkid][STORE_CONFIGURE_REPORTING]
+        and Ep in self.ListOfDevices[Nwkid][STORE_CONFIGURE_REPORTING]["Ep"]
+        and cluster in self.ListOfDevices[Nwkid][STORE_CONFIGURE_REPORTING]["Ep"][Ep]
+    ):
+        self.ListOfDevices[Nwkid][STORE_CONFIGURE_REPORTING]["Ep"][Ep][cluster].pop("MismatchRetry", None)
+
 
 def is_valid_cluster_attribute( self, Nwkid, _ep, _cluster, attribut):
     

--- a/Modules/database.py
+++ b/Modules/database.py
@@ -263,11 +263,15 @@ def LoadDeviceList(self):
             Modules.tools.reset_device_attribute(self, STORE_CONFIGURE_REPORTING, addr)
             Modules.tools.reset_device_attribute(self, STORE_READ_CONFIGURE_REPORTING, addr)
             
-        if ( 
-            STORE_READ_CONFIGURE_REPORTING in self.ListOfDevices[ addr ] 
+        if (
+            STORE_READ_CONFIGURE_REPORTING in self.ListOfDevices[ addr ]
             and "Request" in self.ListOfDevices[ addr ][STORE_READ_CONFIGURE_REPORTING]
         ):
             Modules.tools.reset_device_attribute(self, STORE_READ_CONFIGURE_REPORTING, addr)
+
+        # A plugin restart is a fresh start: drop any Configure Reporting mismatch backoff
+        # counters so devices get a clean set of retry attempts.
+        Modules.tools.reset_mismatch_retry_datastruct(self, STORE_CONFIGURE_REPORTING, addr)
 
         if (
             "Param" in self.ListOfDevices[addr] 

--- a/Modules/tools.py
+++ b/Modules/tools.py
@@ -116,6 +116,7 @@ from Modules.tools_datastruct import (  # noqa: F401
     reset_attr_datastruct,
     reset_cluster_datastruct,
     reset_device_attribute,
+    reset_mismatch_retry_datastruct,
     set_isqn_datastruct,
     set_request_datastruct,
     set_request_phase_datastruct,

--- a/Modules/tools_datastruct.py
+++ b/Modules/tools_datastruct.py
@@ -274,6 +274,23 @@ def reset_device_attribute(self, Nwkid: str, attribute: str) -> None:
     self.ListOfDevices[Nwkid][attribute] = {}
 
 
+def reset_mismatch_retry_datastruct(self, DeviceAttribute, key):
+    """Drop any 'MismatchRetry' Configure Reporting backoff counters for every Ep/cluster of a device.
+
+    Called on plugin restart so devices get a fresh set of retry attempts instead of
+    carrying a stale backoff across restarts; leaves TimeStamp/iSQN/Attributes/ZigateRequest untouched.
+    """
+    if key not in self.ListOfDevices:
+        return
+    device_attr = self.ListOfDevices[key].get(DeviceAttribute)
+    if not device_attr or "Ep" not in device_attr:
+        return
+    for ep_clusters in device_attr["Ep"].values():
+        for cluster in ep_clusters.values():
+            if isinstance(cluster, dict):
+                cluster.pop("MismatchRetry", None)
+
+
 def clean_old_datastruct(self, DeviceAttribute, key, endpoint, clusterId, AttributeId):
     if key not in self.ListOfDevices:
         return False

--- a/tests/Classes/ConfigureReporting/test_configure_reporting_mismatch_retry.py
+++ b/tests/Classes/ConfigureReporting/test_configure_reporting_mismatch_retry.py
@@ -8,9 +8,10 @@ when a device acknowledges (Status 00) a Configure Reporting request but keeps
 reporting back a different Min/Max/Change (firmware silently clamps or ignores
 the request), check_and_redo_configure_reporting_if_needed() used to re-send a
 Configure Reporting (and possibly re-bind) on every ~1 minute heartbeat call,
-forever. It must now stop after MAX_CFG_RPT_MISMATCH_RETRY consecutive
-attempts, back off for CFG_RPT_MISMATCH_BACKOFF seconds, and resume once the
-device actually reports back a matching configuration.
+forever. It must now give up permanently after MAX_CFG_RPT_MISMATCH_RETRY
+consecutive attempts (no more resends until the next plugin restart), while
+still resuming immediately if the device reports back a matching
+configuration in the meantime.
 
 Classes.ConfigureReporting is imported inside a module-scoped fixture, against
 locally stubbed dependencies, and sys.modules is restored on teardown so
@@ -152,8 +153,8 @@ def test_mismatch_retries_are_bounded(cr_module, cr, monkeypatch):
     assert len(sent) == max_retry
 
 
-def test_backoff_releases_after_window_elapses(cr_module, cr, monkeypatch):
-    """Once CFG_RPT_MISMATCH_BACKOFF has elapsed, one more attempt is allowed."""
+def test_gives_up_permanently_until_restart(cr_module, cr, monkeypatch):
+    """After MAX_CFG_RPT_MISMATCH_RETRY, no more attempts are ever sent again for this run."""
     sent = []
     monkeypatch.setattr(cr_module, "configure_reporting_for_one_cluster", lambda *a, **k: sent.append(a))
 
@@ -162,9 +163,14 @@ def test_backoff_releases_after_window_elapses(cr_module, cr, monkeypatch):
         cr.check_and_redo_configure_reporting_if_needed(NWKID)
     assert len(sent) == max_retry
 
-    # Simulate the backoff window having elapsed
-    retry_state = cr.ListOfDevices[NWKID]["ConfigureReporting"]["Ep"][EP][CLUSTER]["MismatchRetry"]
-    retry_state["TimeStamp"] -= cr_module.CFG_RPT_MISMATCH_BACKOFF + 1
+    # No amount of extra heartbeats (or elapsed wall-clock time) brings it back
+    for _ in range(50):
+        cr.check_and_redo_configure_reporting_if_needed(NWKID)
+    assert len(sent) == max_retry
+
+    # A plugin restart clears the counter and gives the device a fresh round of attempts
+    from Modules.tools_datastruct import reset_mismatch_retry_datastruct
+    reset_mismatch_retry_datastruct(cr, "ConfigureReporting", NWKID)
 
     cr.check_and_redo_configure_reporting_if_needed(NWKID)
 
@@ -199,8 +205,9 @@ def test_allow_configure_reporting_retry_logs_give_up_once(cr_module):
     # The "giving up" Status log fires exactly once, on the attempt that hits the cap
     assert o.log.logging.call_count == 1
 
-    # Further calls within the backoff window are denied and do not log again
-    assert cr_module._allow_configure_reporting_retry(o, NWKID, EP, CLUSTER) is False
+    # Further calls are permanently denied and do not log again
+    for _ in range(10):
+        assert cr_module._allow_configure_reporting_retry(o, NWKID, EP, CLUSTER) is False
     assert o.log.logging.call_count == 1
 
 

--- a/tests/Classes/ConfigureReporting/test_configure_reporting_mismatch_retry.py
+++ b/tests/Classes/ConfigureReporting/test_configure_reporting_mismatch_retry.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+test_configure_reporting_mismatch_retry.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Regression test for the infinite "Z4D detects misconfigured reporting" loop:
+when a device acknowledges (Status 00) a Configure Reporting request but keeps
+reporting back a different Min/Max/Change (firmware silently clamps or ignores
+the request), check_and_redo_configure_reporting_if_needed() used to re-send a
+Configure Reporting (and possibly re-bind) on every ~1 minute heartbeat call,
+forever. It must now stop after MAX_CFG_RPT_MISMATCH_RETRY consecutive
+attempts, back off for CFG_RPT_MISMATCH_BACKOFF seconds, and resume once the
+device actually reports back a matching configuration.
+
+Classes.ConfigureReporting is imported inside a module-scoped fixture, against
+locally stubbed dependencies, and sys.modules is restored on teardown so
+neither the conftest stubs nor other test modules are disturbed (same pattern
+as tests/Classes/OTA/test_OTA_heartbeat.py).
+
+Run with:
+    python -m pytest tests/Classes/ConfigureReporting/test_configure_reporting_mismatch_retry.py -v
+"""
+
+import importlib
+import sys
+import time
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_stub(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+NWKID = "35fd"
+EP = "01"
+CLUSTER = "0b04"
+ATTR = "050b"
+
+# Direct imports of Classes/ConfigureReporting.py, stubbed so the import does
+# not drag in the Domoticz framework (Modules.tools -> ... -> DomoticzEx).
+_CR_DEPS = {
+    "Classes.ZigateTransport.sqnMgmt": dict(
+        TYPE_APP_ZCL="zcl",
+        sqn_get_internal_sqn_from_app_sqn=MagicMock(name="sqn_get_internal_sqn_from_app_sqn", return_value=1),
+    ),
+    "Modules.bindings": dict(
+        bindDevice=MagicMock(name="bindDevice"),
+        unbindDevice=MagicMock(name="unbindDevice"),
+    ),
+    "Modules.tools": dict(
+        check_datastruct=__import__("Modules.tools_datastruct", fromlist=["check_datastruct"]).check_datastruct,
+        deviceconf_device=MagicMock(name="deviceconf_device", return_value=True),
+        get_device_config_param=MagicMock(name="get_device_config_param", return_value=None),
+        get_isqn_datastruct=MagicMock(name="get_isqn_datastruct"),
+        get_list_isqn_attr_datastruct=MagicMock(name="get_list_isqn_attr_datastruct", return_value=[]),
+        get_list_isqn_int_attr_datastruct=MagicMock(name="get_list_isqn_int_attr_datastruct", return_value=[]),
+        getClusterListforEP=MagicMock(name="getClusterListforEP", return_value=[]),
+        is_ack_tobe_disabled=MagicMock(name="is_ack_tobe_disabled", return_value=False),
+        is_attr_unvalid_datastruct=MagicMock(name="is_attr_unvalid_datastruct", return_value=False),
+        is_bind_ep=MagicMock(name="is_bind_ep", return_value=True),
+        is_fake_ep=MagicMock(name="is_fake_ep", return_value=False),
+        is_time_to_perform_work=MagicMock(name="is_time_to_perform_work", return_value=True),
+        mainPoweredDevice=MagicMock(name="mainPoweredDevice", return_value=True),
+        reset_attr_datastruct=MagicMock(name="reset_attr_datastruct"),
+        set_isqn_datastruct=MagicMock(name="set_isqn_datastruct"),
+        set_status_datastruct=MagicMock(name="set_status_datastruct"),
+        set_timestamp_datastruct=MagicMock(name="set_timestamp_datastruct"),
+    ),
+    "Zigbee.zclCommands": dict(
+        zcl_configure_reporting_requestv2=MagicMock(name="zcl_configure_reporting_requestv2"),
+        zcl_read_report_config_request=MagicMock(name="zcl_read_report_config_request"),
+    ),
+}
+
+
+
+# These have no heavy dependencies of their own, but other test modules (via the
+# session-wide conftest.py stubs) may have already installed incomplete stand-ins
+# for them under a different value/shape. Force a fresh real import for both.
+_CR_REAL_MODULES = ["Modules.pluginDbAttributes", "Modules.zigateConsts"]
+
+
+@pytest.fixture(scope="module")
+def cr_module():
+    deps_and_self = list(_CR_DEPS) + ["Classes.ConfigureReporting"] + _CR_REAL_MODULES
+    saved = {name: sys.modules.pop(name, None) for name in deps_and_self}
+    for name, attrs in _CR_DEPS.items():
+        sys.modules[name] = _make_stub(name, **attrs)
+
+    module = importlib.import_module("Classes.ConfigureReporting")
+    yield module
+
+    for name in deps_and_self:
+        sys.modules.pop(name, None)
+    for name, mod in saved.items():
+        if mod is not None:
+            sys.modules[name] = mod
+
+
+@pytest.fixture
+def cr(cr_module):
+    """ConfigureReporting instance without running __init__ (no radio, no I/O)."""
+    o = object.__new__(cr_module.ConfigureReporting)
+    o.log = MagicMock()
+    o.DeviceConf = {}
+    o.ListOfDevices = {
+        NWKID: {
+            "Ep": {EP: {CLUSTER: {}}},
+            # Custom override so retreive_configuration_reporting_definition() returns
+            # a small, fully controlled desired configuration.
+            "ParamConfigureReporting": {
+                CLUSTER: {
+                    "Attributes": {
+                        ATTR: {"DataType": "10", "MinInterval": "003c", "MaxInterval": "012c"},
+                    }
+                }
+            },
+            # "ConfigureReporting": non-empty so we skip the "never configured yet" branch.
+            "ConfigureReporting": {"Ep": {EP: {CLUSTER: {"TimeStamp": 0, "iSQN": {}, "Attributes": {}, "ZigateRequest": {}}}}},
+            # Device currently reports back a mismatched MaxInterval (same shape as the
+            # real-world report: attribute 050b, MaxInterval '044c' != desired '012C').
+            "ReadConfigureReporting": {
+                "TimeStamp": time.time(),
+                "Ep": {
+                    EP: {
+                        CLUSTER: {
+                            ATTR: {"DataType": "10", "MinInterval": "003c", "MaxInterval": "044c"},
+                        }
+                    }
+                },
+            },
+        }
+    }
+    return o
+
+
+def test_mismatch_retries_are_bounded(cr_module, cr, monkeypatch):
+    """Configure Reporting must not be re-sent forever for a persistently mismatched device."""
+    sent = []
+    monkeypatch.setattr(cr_module, "configure_reporting_for_one_cluster", lambda *a, **k: sent.append(a))
+
+    max_retry = cr_module.MAX_CFG_RPT_MISMATCH_RETRY
+    for _ in range(max_retry + 10):
+        cr.check_and_redo_configure_reporting_if_needed(NWKID)
+
+    assert len(sent) == max_retry
+
+
+def test_backoff_releases_after_window_elapses(cr_module, cr, monkeypatch):
+    """Once CFG_RPT_MISMATCH_BACKOFF has elapsed, one more attempt is allowed."""
+    sent = []
+    monkeypatch.setattr(cr_module, "configure_reporting_for_one_cluster", lambda *a, **k: sent.append(a))
+
+    max_retry = cr_module.MAX_CFG_RPT_MISMATCH_RETRY
+    for _ in range(max_retry + 3):
+        cr.check_and_redo_configure_reporting_if_needed(NWKID)
+    assert len(sent) == max_retry
+
+    # Simulate the backoff window having elapsed
+    retry_state = cr.ListOfDevices[NWKID]["ConfigureReporting"]["Ep"][EP][CLUSTER]["MismatchRetry"]
+    retry_state["TimeStamp"] -= cr_module.CFG_RPT_MISMATCH_BACKOFF + 1
+
+    cr.check_and_redo_configure_reporting_if_needed(NWKID)
+
+    assert len(sent) == max_retry + 1
+
+
+def test_retry_state_clears_once_device_matches(cr_module, cr, monkeypatch):
+    """Once the device reports back a matching configuration, the backoff counter is dropped."""
+    monkeypatch.setattr(cr_module, "configure_reporting_for_one_cluster", MagicMock())
+
+    cr.check_and_redo_configure_reporting_if_needed(NWKID)
+    cluster_state = cr.ListOfDevices[NWKID]["ConfigureReporting"]["Ep"][EP][CLUSTER]
+    assert "MismatchRetry" in cluster_state
+
+    # Device now reports back the desired MaxInterval
+    cr.ListOfDevices[NWKID]["ReadConfigureReporting"]["Ep"][EP][CLUSTER][ATTR]["MaxInterval"] = "012c"
+
+    cr.check_and_redo_configure_reporting_if_needed(NWKID)
+
+    assert "MismatchRetry" not in cluster_state
+
+
+def test_allow_configure_reporting_retry_logs_give_up_once(cr_module):
+    o = object.__new__(cr_module.ConfigureReporting)
+    o.log = MagicMock()
+    o.ListOfDevices = {NWKID: {}}
+
+    max_retry = cr_module.MAX_CFG_RPT_MISMATCH_RETRY
+    results = [cr_module._allow_configure_reporting_retry(o, NWKID, EP, CLUSTER) for _ in range(max_retry)]
+
+    assert all(results)
+    # The "giving up" Status log fires exactly once, on the attempt that hits the cap
+    assert o.log.logging.call_count == 1
+
+    # Further calls within the backoff window are denied and do not log again
+    assert cr_module._allow_configure_reporting_retry(o, NWKID, EP, CLUSTER) is False
+    assert o.log.logging.call_count == 1
+
+
+def test_clear_configure_reporting_retry_removes_state(cr_module):
+    o = object.__new__(cr_module.ConfigureReporting)
+    o.log = MagicMock()
+    o.ListOfDevices = {NWKID: {}}
+    cr_module._allow_configure_reporting_retry(o, NWKID, EP, CLUSTER)
+    assert "MismatchRetry" in o.ListOfDevices[NWKID]["ConfigureReporting"]["Ep"][EP][CLUSTER]
+
+    cr_module._clear_configure_reporting_retry(o, NWKID, EP, CLUSTER)
+
+    assert "MismatchRetry" not in o.ListOfDevices[NWKID]["ConfigureReporting"]["Ep"][EP][CLUSTER]
+
+
+def test_clear_configure_reporting_retry_unknown_device_no_crash(cr_module):
+    o = object.__new__(cr_module.ConfigureReporting)
+    o.log = MagicMock()
+    o.ListOfDevices = {}
+    cr_module._clear_configure_reporting_retry(o, "dead", EP, CLUSTER)

--- a/tests/Modules/Tools/test_tools_datastruct.py
+++ b/tests/Modules/Tools/test_tools_datastruct.py
@@ -39,6 +39,7 @@ from Modules.tools_datastruct import (
     reset_attr_datastruct,
     reset_cluster_datastruct,
     reset_device_attribute,
+    reset_mismatch_retry_datastruct,
     set_isqn_datastruct,
     set_request_datastruct,
     set_request_phase_datastruct,
@@ -351,3 +352,47 @@ class TestCleanOldDatastruct:
 
     def test_unknown_device_returns_false(self):
         assert clean_old_datastruct(_plugin(), DA, "dead", EP, CL, AT) is False
+
+
+# ---------------------------------------------------------------------------
+# reset_mismatch_retry_datastruct
+# ---------------------------------------------------------------------------
+
+class TestResetMismatchRetryDatastruct:
+    def test_clears_mismatch_retry_keeps_other_keys(self):
+        p = _ready_plugin()
+        cluster = p.ListOfDevices[NWKID][DA]["Ep"][EP][CL]
+        cluster["MismatchRetry"] = {"Count": 3, "TimeStamp": 12345, "Reported": True}
+        set_timestamp_datastruct(p, DA, NWKID, EP, CL, 999)
+        set_isqn_datastruct(p, DA, NWKID, EP, CL, AT, "0a")
+
+        reset_mismatch_retry_datastruct(p, DA, NWKID)
+
+        assert "MismatchRetry" not in cluster
+        # Untouched state used by the rest of the plugin
+        assert cluster["TimeStamp"] == 999
+        assert cluster["iSQN"][AT] == "0a"
+
+    def test_clears_across_multiple_ep_and_clusters(self):
+        p = _ready_plugin()
+        check_datastruct(p, DA, NWKID, "02", "0402")
+        p.ListOfDevices[NWKID][DA]["Ep"][EP][CL]["MismatchRetry"] = {"Count": 1, "TimeStamp": 1, "Reported": False}
+        p.ListOfDevices[NWKID][DA]["Ep"]["02"]["0402"]["MismatchRetry"] = {"Count": 2, "TimeStamp": 2, "Reported": True}
+
+        reset_mismatch_retry_datastruct(p, DA, NWKID)
+
+        assert "MismatchRetry" not in p.ListOfDevices[NWKID][DA]["Ep"][EP][CL]
+        assert "MismatchRetry" not in p.ListOfDevices[NWKID][DA]["Ep"]["02"]["0402"]
+
+    def test_no_mismatch_retry_present_is_a_no_op(self):
+        p = _ready_plugin()
+        # Should not raise even though "MismatchRetry" was never set
+        reset_mismatch_retry_datastruct(p, DA, NWKID)
+        assert "MismatchRetry" not in p.ListOfDevices[NWKID][DA]["Ep"][EP][CL]
+
+    def test_unknown_device_no_crash(self):
+        reset_mismatch_retry_datastruct(_plugin(), DA, "dead")
+
+    def test_device_without_the_attribute_no_crash(self):
+        p = _plugin({NWKID: {}})
+        reset_mismatch_retry_datastruct(p, DA, NWKID)


### PR DESCRIPTION
Fixing: #1999

##  Summary

  - Fixes an infinite loop where devices that acknowledge (Status 00) a Configure Reporting request but keep reporting back a different MinInterval/MaxInterval/Change (e.g. firmware silently clamps or ignores the requested values) were  re-triggered on every ~1 minute heartbeat, forever — flooding the log with repeated Z4D detects misconfigured reporting / forces a Configure Reporting messages and, when allowReBindingClusters is set, re-binding the cluster each time  too.
  - Adds a bounded retry + backoff to check_and_redo_configure_reporting_if_needed, and clears/reset behavior so the fix doesn't mask a genuine future fix (device firmware update, config change, plugin restart).

##  Scope / Details

  - Classes/ConfigureReporting.py
    - New constants MAX_CFG_RPT_MISMATCH_RETRY (3) and CFG_RPT_MISMATCH_BACKOFF (21h, same cadence as the existing reenforcement cycle).
    - New _allow_configure_reporting_retry() / _clear_configure_reporting_retry() helpers, storing a small MismatchRetry: {Count, TimeStamp, Reported} counter per ep/cluster inside the existing ConfigureReporting datastruct.
    - check_and_redo_configure_reporting_if_needed now gates the mismatch-triggered configure_reporting_for_one_cluster() call through this helper: after MAX_CFG_RPT_MISMATCH_RETRY consecutive attempts it backs off for
  CFG_RPT_MISMATCH_BACKOFF seconds and logs a single "giving up" Status line instead of resending every minute. The counter auto-clears once the device reports back a matching configuration.
  - Modules/tools_datastruct.py — new reset_mismatch_retry_datastruct() helper (pure, no heavy deps) that drops the MismatchRetry counter across all ep/clusters for a device, leaving TimeStamp/iSQN/Attributes/ZigateRequest untouched.  Re-exported via Modules/tools.py.
  - Modules/database.py — LoadDeviceList now calls this helper for every device on every plugin start, so a restart always gives devices a fresh set of retry attempts rather than carrying a stale backoff across restarts.
  - No persisted data format changes beyond a new optional sub-key (MismatchRetry) inside the existing ConfigureReporting structure — fully backward compatible, no migration needed.

##  Validation

  - python3 -m py_compile on all changed files — clean.
  - CI-style syntax lint: flake8 . --select=E9,F63,F7,F82 — clean.
  - Full test suite: pytest . — 1301 passed (1290 pre-existing + 11 new).
  - New regression tests:
    - tests/Classes/ConfigureReporting/test_configure_reporting_mismatch_retry.py — reproduces the exact reported scenario (device 35fd, ep 01, cluster 0b04, attribute 050b, MaxInterval mismatch) and asserts: retries are bounded at  MAX_CFG_RPT_MISMATCH_RETRY, backoff releases one more attempt after CFG_RPT_MISMATCH_BACKOFF elapses, and the counter clears once the device reports a matching config.
    - tests/Modules/Tools/test_tools_datastruct.py — new tests for reset_mismatch_retry_datastruct() covering multi-ep/cluster clearing, no-op on missing state, and unknown-device safety (covers the plugin-restart reset path).
