### PR TITLE
Fix AttributeError on repeated onHeartbeat during ErasePDM restart (target: stable9)

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1409,7 +1409,7 @@ def zigateInit_Phase3(self):
 
     if self.transport != "None" and Parameters["Mode3"] == "True" and self.ErasePDMDone and self.domoticzdb_Hardware:
         self.log.logging("Plugin", "Debug", "let's update Mode3 is needed")
-        self.domoticzdb_Hardware.disableErasePDM( self.WebUsername, self.WebPassword)
+        restartPluginViaDomoticzJsonApi(self, stop=False, erasePDM=False, url_base_api=Parameters["Mode5"])
 
     if self.InitPhase3:
         return


### PR DESCRIPTION
## Summary

  Fixes a recurring AttributeError that fires on every onHeartbeat call (~every 5s) once a device's Zigbee coordinator has completed an Erase-PDM cycle. The plugin was calling a method that
  no longer exists on DomoticzDB_Hardware, so the log filled up with the same traceback indefinitely.

##  Root Cause Analysis

  plugin.py::zigateInit_Phase3() calls:

  self.domoticzdb_Hardware.disableErasePDM(self.WebUsername, self.WebPassword)

  whenever Parameters["Mode3"] == "True" and self.ErasePDMDone and self.domoticzdb_Hardware are all set — i.e. right after an Erase-PDM has completed and the plugin needs to flip the Mode3  hardware setting back off.

  Commit 7521af23 ("New rc stable8 8.1.002 (#1916)") completely rewrote Classes/DomoticzDB.py, replacing the old blocking, curl-based DomoticzDB_Hardware class with a new async/cached  DomoticzAPIClient-backed implementation. That rewrite dropped the disableErasePDM method (and the WebUsername/WebPassword signature it took) but the one caller in plugin.py was never  updated to match, leaving a dangling reference to a removed method.

  The old method's body was trivial — it just restarted the plugin via the Domoticz JSON API to clear Mode3:

```
  def disableErasePDM(self, webUserName, webPassword):
      # To disable the ErasePDM, we have to restart the plugin
      # This is usally done after ErasePDM
      restartPluginViaDomoticzJsonApi(self, stop=False, url_base_api=self.api_base_url)
```

  Modules/restartPlugin.py::restartPluginViaDomoticzJsonApi still exists today, is already imported in plugin.py, and is already used the same way at three other call sites (plugin.py:900,  1682, 1933). It even has a dedicated erasePDM kwarg that explicitly sets Mode3 on the hardware-update API call, making it a more correct fit than the old method it replaces.

##  Scope

  - File changed: plugin.py (1 line)
  - Function: zigateInit_Phase3(), called from onHeartbeat()
  - Behavior change: Replaces the dead disableErasePDM() call with the existing, already-proven restartPluginViaDomoticzJsonApi(self, stop=False, erasePDM=False,  url_base_api=Parameters["Mode5"]) — same pattern used elsewhere in the file, no new imports needed (restartPluginViaDomoticzJsonApi was already imported at the top of plugin.py).
  - No changes to Classes/DomoticzDB.py, persistence formats, or device schema. No lifecycle/state changes beyond fixing this one call site.

##  Verification

  - python3 -c "import ast; ast.parse(open('plugin.py').read())" — syntax OK
  - flake8 plugin.py --builtins=Devices,Parameters,Connection --count --select=E9,F63,F7,F82 --show-source --statistics — 0 errors (matches CI's lint gate)
  - Manual trace confirms restartPluginViaDomoticzJsonApi is already imported and used identically elsewhere in plugin.py (lines 900, 1682, 1933), so the call signature and behavior are
  already exercised in production code paths.
  - Not yet tested against a live coordinator performing an actual Erase-PDM cycle (would need hardware in that specific state) — recommend confirming Mode3 clears correctly and the plugin  restarts cleanly on a test rig before merging to a production branch.